### PR TITLE
[SYNC] Generic scheme meet / scheme utils update

### DIFF
--- a/src/engine/core/managers/interaction/SleepManager.ts
+++ b/src/engine/core/managers/interaction/SleepManager.ts
@@ -41,7 +41,7 @@ export class SleepManager extends AbstractCoreManager {
     }
 
     this.sleepDialog.uiTimeTrack.SetCurrentValue();
-    this.sleepDialog.testAndShow();
+    this.sleepDialog.showSleepOptions();
   }
 
   /**

--- a/src/engine/core/managers/interface/ActorInputManager.ts
+++ b/src/engine/core/managers/interface/ActorInputManager.ts
@@ -6,7 +6,17 @@ import { SchemeNoWeapon } from "@/engine/core/schemes/sr_no_weapon";
 import { readTimeFromPacket, writeTimeToPacket } from "@/engine/core/utils/game/game_time";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { misc } from "@/engine/lib/constants/items/misc";
-import { ClientObject, GameHud, NetPacket, NetProcessor, Optional, TDuration, Time, TIndex } from "@/engine/lib/types";
+import {
+  ClientObject,
+  EActiveItemSlot,
+  GameHud,
+  NetPacket,
+  NetProcessor,
+  Optional,
+  TDuration,
+  Time,
+  TIndex,
+} from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 
@@ -14,22 +24,13 @@ const logger: LuaLogger = new LuaLogger($filename);
  * Manager to handle actor input.
  */
 export class ActorInputManager extends AbstractCoreManager {
-  /**
-   * Item slot `none`.
-   */
-  public static readonly NONE_ITEM_SLOT: TIndex = 0;
-  /**
-   * Item slot applied by default when game is started.
-   */
-  public static readonly DEFAULT_ACTIVE_ITEM_SLOT: TIndex = 3;
-
   public isWeaponHidden: boolean = false;
   public isWeaponHiddenInDialog: boolean = false;
   public isActorNightVisionEnabled: boolean = false;
   public isActorTorchEnabled: boolean = false;
 
-  public activeItemSlot: TIndex = ActorInputManager.DEFAULT_ACTIVE_ITEM_SLOT;
-  public memoizedItemSlot: TIndex = ActorInputManager.NONE_ITEM_SLOT;
+  public activeItemSlot: EActiveItemSlot = EActiveItemSlot.PRIMARY;
+  public memoizedItemSlot: EActiveItemSlot = EActiveItemSlot.NONE;
 
   public disableInputAt: Optional<Time> = null;
   public disableInputDuration: Optional<TDuration> = null;
@@ -148,9 +149,9 @@ export class ActorInputManager extends AbstractCoreManager {
     if (resetSlot) {
       const slot: TIndex = actor.active_slot();
 
-      if (slot !== ActorInputManager.NONE_ITEM_SLOT) {
+      if (slot !== EActiveItemSlot.NONE) {
         this.memoizedItemSlot = slot;
-        actor.activate_slot(ActorInputManager.NONE_ITEM_SLOT);
+        actor.activate_slot(EActiveItemSlot.NONE);
       }
     }
 
@@ -174,14 +175,14 @@ export class ActorInputManager extends AbstractCoreManager {
 
     if (restore) {
       if (
-        this.memoizedItemSlot !== ActorInputManager.NONE_ITEM_SLOT &&
+        this.memoizedItemSlot !== EActiveItemSlot.NONE &&
         registry.actor.item_in_slot(this.memoizedItemSlot) !== null
       ) {
         registry.actor.activate_slot(this.memoizedItemSlot);
       }
     }
 
-    this.memoizedItemSlot = ActorInputManager.NONE_ITEM_SLOT;
+    this.memoizedItemSlot = EActiveItemSlot.NONE;
 
     level.show_weapon(true);
     level.enable_input();
@@ -205,9 +206,9 @@ export class ActorInputManager extends AbstractCoreManager {
 
     const slot: TIndex = actor.active_slot();
 
-    if (slot !== ActorInputManager.NONE_ITEM_SLOT) {
+    if (slot !== EActiveItemSlot.NONE) {
       this.memoizedItemSlot = slot;
-      actor.activate_slot(ActorInputManager.NONE_ITEM_SLOT);
+      actor.activate_slot(EActiveItemSlot.NONE);
     }
 
     level.disable_input();

--- a/src/engine/core/managers/interface/MapDisplayManager.ts
+++ b/src/engine/core/managers/interface/MapDisplayManager.ts
@@ -12,9 +12,9 @@ import {
 import { SmartTerrain, Squad } from "@/engine/core/objects";
 import { parseConditionsList, pickSectionFromCondList, readIniString, TConditionList } from "@/engine/core/utils/ini";
 import { LuaLogger } from "@/engine/core/utils/logging";
-import { isSquadMonsterCommunity } from "@/engine/core/utils/object";
 import { getAnomalyArtefacts } from "@/engine/core/utils/object/object_anomaly";
 import { hasAlifeInfo } from "@/engine/core/utils/object/object_info_portion";
+import { isSquadMonsterCommunity } from "@/engine/core/utils/object/object_section";
 import {
   ERelation,
   getSquadMembersRelationToActor,

--- a/src/engine/core/managers/interface/notifications/NotificationManager.ts
+++ b/src/engine/core/managers/interface/notifications/NotificationManager.ts
@@ -29,8 +29,8 @@ import { GlobalSoundManager } from "@/engine/core/managers/sounds/GlobalSoundMan
 import { Stalker } from "@/engine/core/objects";
 import { abort, assert } from "@/engine/core/utils/assertion";
 import { LuaLogger } from "@/engine/core/utils/logging";
-import { isObjectWounded } from "@/engine/core/utils/object";
 import { getInventoryNameForItemSection } from "@/engine/core/utils/object/object_spawn";
+import { isObjectWounded } from "@/engine/core/utils/object/object_state";
 import { captions, TCaption } from "@/engine/lib/constants/captions/captions";
 import { scriptSounds } from "@/engine/lib/constants/sound/script_sounds";
 import { textures, TTexture } from "@/engine/lib/constants/textures";

--- a/src/engine/core/objects/animation/animations/base.ts
+++ b/src/engine/core/objects/animation/animations/base.ts
@@ -5,6 +5,7 @@ import { finishHelpWounded } from "@/engine/core/schemes/help_wounded/utils";
 import { createSequence } from "@/engine/core/utils/animation";
 import { getExtern } from "@/engine/core/utils/binding";
 import { startPlayingGuitar, startPlayingHarmonica } from "@/engine/core/utils/camp";
+import { clearObjectAbuse, objectPunchActor } from "@/engine/core/utils/object";
 import { AnyCallablesModule, ClientObject, TName } from "@/engine/lib/types";
 
 /**
@@ -399,54 +400,54 @@ export const baseAnimations: LuaTable<TName, IAnimationDescriptor> = $fromObject
     into: createSequence(
       [
         "norm_facer_0_0",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").actor_punch(...args) },
+        { f: (object: ClientObject) => objectPunchActor(object) },
         "norm_facer_0_1",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").clearAbuse(...args) },
+        { f: (object: ClientObject) => clearObjectAbuse(object) },
       ],
       [
         "norm_facer_1_0",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").actor_punch(...args) },
+        { f: (object: ClientObject) => objectPunchActor(object) },
         "norm_facer_1_1",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").clearAbuse(...args) },
+        { f: (object: ClientObject) => clearObjectAbuse(object) },
       ],
       [
         "norm_facer_2_0",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").actor_punch(...args) },
+        { f: (object: ClientObject) => objectPunchActor(object) },
         "norm_facer_2_1",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").clearAbuse(...args) },
+        { f: (object: ClientObject) => clearObjectAbuse(object) },
       ],
       [
         "norm_facer_3_0",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").actor_punch(...args) },
+        { f: (object: ClientObject) => objectPunchActor(object) },
         "norm_facer_3_1",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").clearAbuse(...args) },
+        { f: (object: ClientObject) => clearObjectAbuse(object) },
       ],
       [
         "norm_facer_4_0",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").actor_punch(...args) },
+        { f: (object: ClientObject) => objectPunchActor(object) },
         "norm_facer_4_1",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").clearAbuse(...args) },
+        { f: (object: ClientObject) => clearObjectAbuse(object) },
       ],
       null,
       null,
       null,
       [
         "norm_facer_8_0",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").actor_punch(...args) },
+        { f: (object: ClientObject) => objectPunchActor(object) },
         "norm_facer_8_1",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").clearAbuse(...args) },
+        { f: (object: ClientObject) => clearObjectAbuse(object) },
       ],
       [
         "norm_facer_9_0",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").actor_punch(...args) },
+        { f: (object: ClientObject) => objectPunchActor(object) },
         "norm_facer_9_1",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").clearAbuse(...args) },
+        { f: (object: ClientObject) => clearObjectAbuse(object) },
       ],
       [
         "norm_facer_10_0",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").actor_punch(...args) },
+        { f: (object: ClientObject) => objectPunchActor(object) },
         "norm_facer_10_1",
-        { f: (...args: Array<any>) => getExtern<AnyCallablesModule>("xr_effects").clearAbuse(...args) },
+        { f: (object: ClientObject) => clearObjectAbuse(object) },
       ]
     ),
     out: null,

--- a/src/engine/core/objects/state/state/EvaluatorStateLocked.ts
+++ b/src/engine/core/objects/state/state/EvaluatorStateLocked.ts
@@ -19,7 +19,7 @@ export class EvaluatorStateLocked extends property_evaluator {
   }
 
   /**
-   * todo;
+   * Check if state is locked and cannot be changed in this period.
    */
   public override evaluate(): boolean {
     return (

--- a/src/engine/core/schemes/abuse/SchemeAbuse.ts
+++ b/src/engine/core/schemes/abuse/SchemeAbuse.ts
@@ -73,48 +73,4 @@ export class SchemeAbuse extends AbstractScheme {
     state: IRegistryObjectState,
     section: TSection
   ): void {}
-
-  /**
-   * Increment abuse for object.
-   */
-  public static addAbuse(object: ClientObject, value: TCount): void {
-    const abuseState: Optional<ISchemeAbuseState> = registry.objects.get(object.id())[
-      SchemeAbuse.SCHEME_SECTION
-    ] as ISchemeAbuseState;
-
-    abuseState?.abuseManager.addAbuse(value);
-  }
-
-  /**
-   * Clear abuse state for object.
-   */
-  public static clearAbuse(object: ClientObject): void {
-    const state: Optional<ISchemeAbuseState> = registry.objects.get(object.id())[
-      SchemeAbuse.SCHEME_SECTION
-    ] as ISchemeAbuseState;
-
-    state?.abuseManager.clearAbuse();
-  }
-
-  /**
-   * Disable abuse for object.
-   */
-  public static disableAbuse(object: ClientObject): void {
-    const state: Optional<ISchemeAbuseState> = registry.objects.get(object.id())[
-      SchemeAbuse.SCHEME_SECTION
-    ] as ISchemeAbuseState;
-
-    state?.abuseManager.disableAbuse();
-  }
-
-  /**
-   * Enable abuse for object.
-   */
-  public static enableAbuse(object: ClientObject): void {
-    const state: Optional<ISchemeAbuseState> = registry.objects.get(object.id())[
-      SchemeAbuse.SCHEME_SECTION
-    ] as ISchemeAbuseState;
-
-    state?.abuseManager.enableAbuse();
-  }
 }

--- a/src/engine/core/schemes/meet/ISchemeMeetState.ts
+++ b/src/engine/core/schemes/meet/ISchemeMeetState.ts
@@ -4,30 +4,40 @@ import type { TConditionList } from "@/engine/core/utils/ini/ini_types";
 import type { Optional, TDistance, TSection } from "@/engine/lib/types";
 
 /**
+ * Approximate meet distance to simplify logical checks.
+ */
+export enum EMeetDistance {
+  CLOSE = 1,
+  FAR = 2,
+}
+
+/**
  * Scheme state representing `meet` configuration for specific object.
  */
 export interface ISchemeMeetState extends IBaseSchemeState {
   meetManager: MeetManager;
-  snd_on_use: TConditionList;
-  use: TConditionList;
-  meet_dialog: TConditionList;
-  abuse: TConditionList;
-  trade_enable: TConditionList;
-  allow_break: TConditionList;
-  meet_on_talking: TConditionList;
-  use_text: TConditionList;
-  close_distance: TConditionList;
-  close_anim: TConditionList;
-  close_snd_distance: TConditionList;
-  close_snd_hello: TConditionList;
-  close_snd_bye: TConditionList;
-  close_victim: TConditionList;
-  far_distance: TConditionList;
-  far_anim: TConditionList;
-  far_snd_distance: TConditionList;
-  far_snd: TConditionList;
-  far_victim: TConditionList;
   meetSection: Optional<TSection>;
-  reset_distance: TDistance;
-  meet_only_at_path: boolean;
+  abuse: TConditionList;
+  use: TConditionList;
+  useText: TConditionList;
+  useSound: TConditionList;
+  meetDialog: TConditionList;
+  isMeetOnlyAtPathEnabled: boolean;
+  isTradeEnabled: TConditionList;
+  isBreakAllowed: TConditionList;
+  isMeetOnTalking: TConditionList;
+  // Distance to reset state.
+  resetDistance: TDistance;
+  // Distance considered close for meeting.
+  closeDistance: TConditionList;
+  closeAnimation: TConditionList;
+  closeSoundDistance: TConditionList;
+  closeSoundHello: TConditionList;
+  closeSoundBye: TConditionList;
+  closeVictim: TConditionList;
+  farDistance: TConditionList;
+  farAnimation: TConditionList;
+  farSoundDistance: TConditionList;
+  farSound: TConditionList;
+  farVictim: TConditionList;
 }

--- a/src/engine/core/schemes/meet/MeetManager.ts
+++ b/src/engine/core/schemes/meet/MeetManager.ts
@@ -20,6 +20,7 @@ const logger: LuaLogger = new LuaLogger($filename);
  * Approximate meet distance to simplify logical checks.
  */
 enum EMeetDistance {
+  NONE = 0,
   CLOSE = 1,
   FAR = 2,
 }

--- a/src/engine/core/schemes/meet/README.md
+++ b/src/engine/core/schemes/meet/README.md
@@ -5,4 +5,23 @@ description
 ## ini parameters
 
 ```
+close_distance - ?
+close_anim - ?
+close_snd_distance - ?
+close_snd_hello - ?
+close_snd_bye - ?
+close_victim - ?
+far_distance - ?
+far_anim - ?
+far_snd_distance - ?
+far_snd - ?
+far_victim - ?
+snd_on_use - ?
+use - ?
+meet_dialog - ?
+abuse - ?
+trade_enable - ?
+allow_break - ?
+meet_on_talking - ?
+use_text - ?
 ```

--- a/src/engine/core/schemes/meet/SchemeMeet.ts
+++ b/src/engine/core/schemes/meet/SchemeMeet.ts
@@ -91,7 +91,7 @@ export class SchemeMeet extends AbstractScheme {
         ? readIniString(state.ini, state.sectionLogic, SchemeMeet.SCHEME_SECTION, false, "")
         : readIniString(state.ini, section, SchemeMeet.SCHEME_SECTION, false, "");
 
-    initializeMeetScheme(object, state.ini, meetSection, state.meet as ISchemeMeetState, scheme);
+    initializeMeetScheme(object, state.ini, meetSection, state.meet as ISchemeMeetState);
   }
 
   /**

--- a/src/engine/core/schemes/meet/utils/meet_defaults.test.ts
+++ b/src/engine/core/schemes/meet/utils/meet_defaults.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { meetEnemyDefaults, meetNeutralDefaults } from "@/engine/core/schemes/meet/utils/meet_defaults";
+import { FALSE, NIL, TRUE } from "@/engine/lib/constants/words";
+
+describe("meet scheme defaults", () => {
+  it("should have correct defaults fields for enemies", () => {
+    expect(meetEnemyDefaults).toEqual({
+      abuse: FALSE,
+      isBreakAllowed: TRUE,
+      closeAnimation: NIL,
+      closeDistance: "0",
+      closeSoundBye: NIL,
+      close_snd_distance: "0",
+      closeSoundHello: NIL,
+      closeVictim: NIL,
+      farAnimation: NIL,
+      farDistance: "0",
+      farSound: NIL,
+      farSoundDistance: "0",
+      farVictim: NIL,
+      meetDialog: NIL,
+      isMeetOnTalking: FALSE,
+      useSound: NIL,
+      isTradeEnabled: TRUE,
+      use: FALSE,
+      useText: NIL,
+    });
+  });
+
+  it("should have correct defaults fields for neutrals", () => {
+    expect(meetNeutralDefaults).toEqual({
+      abuse: "{=has_enemy} false, true",
+      isBreakAllowed: TRUE,
+      closeAnimation: "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default",
+      closeDistance: "{=is_wounded} 0, {!is_squad_commander} 0, 3",
+      closeSoundBye:
+        "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello",
+      close_snd_distance: "{=is_wounded} 0, {!is_squad_commander} 0, 3",
+      closeSoundHello:
+        "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} meet_hide_weapon," +
+        " meet_hello",
+      closeVictim: "{=is_wounded} nil, {!is_squad_commander} nil, actor",
+      farAnimation: NIL,
+      farDistance: "{=is_wounded} 0, {!is_squad_commander} 0, 5",
+      farSound: NIL,
+      farSoundDistance: "{=is_wounded} 0, {!is_squad_commander} 0, 5",
+      farVictim: NIL,
+      meetDialog: NIL,
+      isMeetOnTalking: TRUE,
+      useSound:
+        "{=is_wounded} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_enemy} nil," +
+        " {=has_enemy} meet_use_no_fight, {=actor_has_weapon} meet_use_no_weapon, {!dist_to_actor_le(3)} nil",
+      isTradeEnabled: TRUE,
+      use:
+        "{=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false," +
+        " {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false",
+      useText: NIL,
+    });
+  });
+});

--- a/src/engine/core/schemes/meet/utils/meet_defaults.ts
+++ b/src/engine/core/schemes/meet/utils/meet_defaults.ts
@@ -1,0 +1,58 @@
+import { FALSE, NIL, TRUE } from "@/engine/lib/constants/words";
+
+/**
+ * Meet scheme defaults for enemies.
+ */
+export const meetEnemyDefaults = {
+  abuse: FALSE,
+  isBreakAllowed: TRUE,
+  closeAnimation: NIL,
+  closeDistance: "0",
+  closeSoundBye: NIL,
+  close_snd_distance: "0",
+  closeSoundHello: NIL,
+  closeVictim: NIL,
+  farAnimation: NIL,
+  farDistance: "0",
+  farSound: NIL,
+  farSoundDistance: "0",
+  farVictim: NIL,
+  meetDialog: NIL,
+  isMeetOnTalking: FALSE,
+  useSound: NIL,
+  isTradeEnabled: TRUE,
+  use: FALSE,
+  useText: NIL,
+} as const;
+
+/**
+ * Meet scheme defaults for neutral and friendly.
+ */
+export const meetNeutralDefaults = {
+  abuse: "{=has_enemy} false, true",
+  isBreakAllowed: "true",
+  closeAnimation: "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default",
+  closeDistance: "{=is_wounded} 0, {!is_squad_commander} 0, 3",
+  closeSoundBye:
+    "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello",
+  close_snd_distance: "{=is_wounded} 0, {!is_squad_commander} 0, 3",
+  closeSoundHello:
+    "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil," +
+    " {=actor_has_weapon} meet_hide_weapon, meet_hello",
+  closeVictim: "{=is_wounded} nil, {!is_squad_commander} nil, actor",
+  farAnimation: "nil",
+  farDistance: "{=is_wounded} 0, {!is_squad_commander} 0, 5",
+  farSound: "nil",
+  farSoundDistance: "{=is_wounded} 0, {!is_squad_commander} 0, 5",
+  farVictim: "nil",
+  meetDialog: "nil",
+  isMeetOnTalking: "true",
+  useSound:
+    "{=is_wounded} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_enemy} nil," +
+    " {=has_enemy} meet_use_no_fight, {=actor_has_weapon} meet_use_no_weapon, {!dist_to_actor_le(3)} nil",
+  isTradeEnabled: "true",
+  use:
+    "{=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false," +
+    " {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false",
+  useText: "nil",
+} as const;

--- a/src/engine/core/schemes/meet/utils/meet_handling.ts
+++ b/src/engine/core/schemes/meet/utils/meet_handling.ts
@@ -1,12 +1,16 @@
 import { registry } from "@/engine/core/database";
 import { GlobalSoundManager } from "@/engine/core/managers/sounds/GlobalSoundManager";
-import { SchemeAbuse } from "@/engine/core/schemes/abuse";
 import { ISchemeMeetState } from "@/engine/core/schemes/meet";
 import { MeetManager } from "@/engine/core/schemes/meet/MeetManager";
 import { ISchemeWoundedState } from "@/engine/core/schemes/wounded";
 import { pickSectionFromCondList } from "@/engine/core/utils/ini";
 import { LuaLogger } from "@/engine/core/utils/logging";
-import { isObjectHelpingWounded, isObjectSearchingCorpse, isObjectWounded } from "@/engine/core/utils/object";
+import {
+  addObjectAbuse,
+  isObjectHelpingWounded,
+  isObjectSearchingCorpse,
+  isObjectWounded,
+} from "@/engine/core/utils/object";
 import { getObjectsRelationSafe } from "@/engine/core/utils/relation";
 import { FALSE, NIL, TRUE } from "@/engine/lib/constants/words";
 import { ClientObject, EClientObjectRelation, EScheme, Optional, TName } from "@/engine/lib/types";
@@ -70,19 +74,19 @@ export function activateMeetWithObject(object: ClientObject): void {
   logger.info("Activate meet interaction:", object.name());
 
   const actor: ClientObject = registry.actor;
-  const sound: Optional<TName> = pickSectionFromCondList(actor, object, state.snd_on_use);
+  const sound: Optional<TName> = pickSectionFromCondList(actor, object, state.useSound);
 
   if (tostring(sound) !== NIL) {
-    GlobalSoundManager.getInstance().playSound(object.id(), sound, null, null);
+    GlobalSoundManager.getInstance().playSound(object.id(), sound);
   }
 
   const meetManager: MeetManager = state.meetManager;
 
   if (
     meetManager.use === FALSE &&
-    meetManager.abuseMode === TRUE &&
+    meetManager.isAbuseModeEnabled === TRUE &&
     getObjectsRelationSafe(object, actor) !== EClientObjectRelation.ENEMY
   ) {
-    SchemeAbuse.addAbuse(object, 1);
+    addObjectAbuse(object, 1);
   }
 }

--- a/src/engine/core/schemes/meet/utils/meet_initialize.ts
+++ b/src/engine/core/schemes/meet/utils/meet_initialize.ts
@@ -1,144 +1,114 @@
 import { registry } from "@/engine/core/database";
 import { ISchemeMeetState } from "@/engine/core/schemes/meet";
+import { meetEnemyDefaults, meetNeutralDefaults } from "@/engine/core/schemes/meet/utils/meet_defaults";
 import { parseConditionsList, readIniString } from "@/engine/core/utils/ini";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { getObjectsRelationSafe } from "@/engine/core/utils/relation";
 import { logicsConfig } from "@/engine/lib/configs/LogicsConfig";
+import { NO_MEET_SECTION } from "@/engine/lib/constants/sections";
 import { FALSE, NIL, TRUE } from "@/engine/lib/constants/words";
-import { AnyObject, ClientObject, EClientObjectRelation, EScheme, IniFile, TSection } from "@/engine/lib/types";
+import { ClientObject, EClientObjectRelation, IniFile, Optional, TSection } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 
 /**
- * todo: Description.
+ * Initialize meet scheme defaults based on object relations and current section logics preferences.
+ *
+ * @param object - target client object
+ * @param ini - target ini file to read config from
+ * @param section - currently active section
+ * @param state - target meet scheme logics state
  */
 export function initializeMeetScheme(
   object: ClientObject,
   ini: IniFile,
   section: TSection,
-  state: ISchemeMeetState,
-  scheme: EScheme
+  state: ISchemeMeetState
 ): void {
+  // Section not changed, nothing to re-init.
   if (tostring(section) === state.meetSection && tostring(section) !== NIL) {
     return;
   }
 
   state.meetSection = tostring(section);
 
-  const def: AnyObject = {};
-  const relation = getObjectsRelationSafe(object, registry.actor);
+  const relation: Optional<EClientObjectRelation> = getObjectsRelationSafe(object, registry.actor);
 
-  if (relation === EClientObjectRelation.ENEMY) {
-    def.close_distance = "0";
-    def.close_anim = NIL;
-    def.close_snd_distance = "0";
-    def.close_snd_hello = NIL;
-    def.close_snd_bye = NIL;
-    def.close_victim = NIL;
-    def.far_distance = "0";
-    def.far_anim = NIL;
-    def.far_snd_distance = "0";
-    def.far_snd = NIL;
-    def.far_victim = NIL;
-    def.snd_on_use = NIL;
-    def.use = FALSE;
-    def.meet_dialog = NIL;
-    def.abuse = FALSE;
-    def.trade_enable = TRUE;
-    def.allow_break = TRUE;
-    def.meet_on_talking = FALSE;
-    def.use_text = NIL;
-  } else {
-    def.close_distance = "{=is_wounded} 0, {!is_squad_commander} 0, 3";
-    def.close_anim = "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_has_weapon} threat_na, talk_default";
-    def.close_snd_distance = "{=is_wounded} 0, {!is_squad_commander} 0, 3";
-    def.close_snd_hello =
-      "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil," +
-      " {=actor_has_weapon} meet_hide_weapon, meet_hello";
-    def.close_snd_bye =
-      "{=is_wounded} nil, {!is_squad_commander} nil, {=actor_enemy} nil, {=actor_has_weapon} nil, meet_hello";
-    def.close_victim = "{=is_wounded} nil, {!is_squad_commander} nil, actor";
-    def.far_distance = "{=is_wounded} 0, {!is_squad_commander} 0, 5";
-    def.far_anim = NIL;
-    def.far_snd_distance = "{=is_wounded} 0, {!is_squad_commander} 0, 5";
-    def.far_snd = NIL;
-    def.far_victim = NIL;
-    def.snd_on_use =
-      "{=is_wounded} nil, {!is_squad_commander} meet_use_no_talk_leader, {=actor_enemy} nil," +
-      " {=has_enemy} meet_use_no_fight, {=actor_has_weapon} meet_use_no_weapon, {!dist_to_actor_le(3)} v";
-    def.use =
-      "{=is_wounded} false, {!is_squad_commander} false, {=actor_enemy} false, {=has_enemy} false," +
-      " {=actor_has_weapon} false, {=dist_to_actor_le(3)} true, false";
-    def.meet_dialog = NIL;
-    def.abuse = "{=has_enemy} false, true";
-    def.trade_enable = TRUE;
-    def.allow_break = TRUE;
-    def.meet_on_talking = TRUE;
-    def.use_text = NIL;
-  }
+  // Meet is disabled, mark sections as disabled.
+  if (tostring(section) === NO_MEET_SECTION) {
+    state.closeDistance = parseConditionsList("0");
+    state.closeAnimation = parseConditionsList(NIL);
+    state.closeSoundDistance = parseConditionsList("0");
+    state.closeSoundHello = parseConditionsList(NIL);
+    state.closeSoundBye = parseConditionsList(NIL);
+    state.closeVictim = parseConditionsList(NIL);
 
-  if (tostring(section) === "no_meet") {
-    state.close_distance = parseConditionsList("0");
-    state.close_anim = parseConditionsList(NIL);
-    state.close_snd_distance = parseConditionsList("0");
-    state.close_snd_hello = parseConditionsList(NIL);
-    state.close_snd_bye = parseConditionsList(NIL);
-    state.close_victim = parseConditionsList(NIL);
+    state.farDistance = parseConditionsList("0");
+    state.farAnimation = parseConditionsList(NIL);
+    state.farSoundDistance = parseConditionsList("0");
+    state.farSound = parseConditionsList(NIL);
+    state.farVictim = parseConditionsList(NIL);
 
-    state.far_distance = parseConditionsList("0");
-    state.far_anim = parseConditionsList(NIL);
-    state.far_snd_distance = parseConditionsList("0");
-    state.far_snd = parseConditionsList(NIL);
-    state.far_victim = parseConditionsList(NIL);
-
-    state.snd_on_use = parseConditionsList(NIL);
+    state.useSound = parseConditionsList(NIL);
     state.use = parseConditionsList(FALSE);
-    state.meet_dialog = parseConditionsList(NIL);
+    state.meetDialog = parseConditionsList(NIL);
     state.abuse = parseConditionsList(FALSE);
-    state.trade_enable = parseConditionsList(TRUE);
-    state.allow_break = parseConditionsList(TRUE);
-    state.meet_on_talking = parseConditionsList(FALSE);
-    state.use_text = parseConditionsList(NIL);
+    state.isTradeEnabled = parseConditionsList(TRUE);
+    state.isBreakAllowed = parseConditionsList(TRUE);
+    state.isMeetOnTalking = parseConditionsList(FALSE);
+    state.useText = parseConditionsList(NIL);
 
-    state.reset_distance = logicsConfig.MEET_RESET_DISTANCE;
-    state.meet_only_at_path = true;
+    state.resetDistance = logicsConfig.MEET_RESET_DISTANCE;
+    state.isMeetOnlyAtPathEnabled = true;
   } else {
-    state.close_distance = parseConditionsList(
-      readIniString(ini, section, "close_distance", false, "", def.close_distance)
-    );
-    state.close_anim = parseConditionsList(readIniString(ini, section, "close_anim", false, "", def.close_anim));
-    state.close_snd_distance = parseConditionsList(
-      readIniString(ini, section, "close_snd_distance", false, "", def.close_distance)
-    );
-    state.close_snd_hello = parseConditionsList(
-      readIniString(ini, section, "close_snd_hello", false, "", def.close_snd_hello)
-    );
-    state.close_snd_bye = parseConditionsList(
-      readIniString(ini, section, "close_snd_bye", false, "", def.close_snd_bye)
-    );
-    state.close_victim = parseConditionsList(readIniString(ini, section, "close_victim", false, "", def.close_victim));
+    const defaults = relation === EClientObjectRelation.ENEMY ? meetEnemyDefaults : meetNeutralDefaults;
 
-    state.far_distance = parseConditionsList(readIniString(ini, section, "far_distance", false, "", def.far_distance));
-    state.far_anim = parseConditionsList(readIniString(ini, section, "far_anim", false, "", def.far_anim));
-    state.far_snd_distance = parseConditionsList(
-      readIniString(ini, section, "far_snd_distance", false, "", def.far_snd_distance)
+    state.closeDistance = parseConditionsList(
+      readIniString(ini, section, "close_distance", false, "", defaults.closeDistance)
     );
-    state.far_snd = parseConditionsList(readIniString(ini, section, "far_snd", false, "", def.far_snd));
-    state.far_victim = parseConditionsList(readIniString(ini, section, "far_victim", false, "", def.far_victim));
-
-    state.snd_on_use = parseConditionsList(readIniString(ini, section, "snd_on_use", false, "", def.snd_on_use));
-    state.use = parseConditionsList(readIniString(ini, section, "use", false, "", def.use));
-    state.meet_dialog = parseConditionsList(readIniString(ini, section, "meet_dialog", false, "", def.meet_dialog));
-    state.abuse = parseConditionsList(readIniString(ini, section, "abuse", false, "", def.abuse));
-    state.trade_enable = parseConditionsList(readIniString(ini, section, "trade_enable", false, "", def.trade_enable));
-    state.allow_break = parseConditionsList(readIniString(ini, section, "allow_break", false, "", def.allow_break));
-    state.meet_on_talking = parseConditionsList(
-      readIniString(ini, section, "meet_on_talking", false, "", def.meet_on_talking)
+    state.closeAnimation = parseConditionsList(
+      readIniString(ini, section, "close_anim", false, "", defaults.closeAnimation)
     );
-    state.use_text = parseConditionsList(readIniString(ini, section, "use_text", false, "", def.use_text));
+    state.closeSoundDistance = parseConditionsList(
+      readIniString(ini, section, "close_snd_distance", false, "", defaults.closeDistance)
+    );
+    state.closeSoundHello = parseConditionsList(
+      readIniString(ini, section, "close_snd_hello", false, "", defaults.closeSoundHello)
+    );
+    state.closeSoundBye = parseConditionsList(
+      readIniString(ini, section, "close_snd_bye", false, "", defaults.closeSoundBye)
+    );
+    state.closeVictim = parseConditionsList(
+      readIniString(ini, section, "close_victim", false, "", defaults.closeVictim)
+    );
 
-    state.reset_distance = logicsConfig.MEET_RESET_DISTANCE;
-    state.meet_only_at_path = true;
+    state.farDistance = parseConditionsList(
+      readIniString(ini, section, "far_distance", false, "", defaults.farDistance)
+    );
+    state.farAnimation = parseConditionsList(readIniString(ini, section, "far_anim", false, "", defaults.farAnimation));
+    state.farSoundDistance = parseConditionsList(
+      readIniString(ini, section, "far_snd_distance", false, "", defaults.farSoundDistance)
+    );
+    state.farSound = parseConditionsList(readIniString(ini, section, "far_snd", false, "", defaults.farSound));
+    state.farVictim = parseConditionsList(readIniString(ini, section, "far_victim", false, "", defaults.farVictim));
+
+    state.useSound = parseConditionsList(readIniString(ini, section, "snd_on_use", false, "", defaults.useSound));
+    state.use = parseConditionsList(readIniString(ini, section, "use", false, "", defaults.use));
+    state.meetDialog = parseConditionsList(readIniString(ini, section, "meet_dialog", false, "", defaults.meetDialog));
+    state.abuse = parseConditionsList(readIniString(ini, section, "abuse", false, "", defaults.abuse));
+    state.isTradeEnabled = parseConditionsList(
+      readIniString(ini, section, "trade_enable", false, "", defaults.isTradeEnabled)
+    );
+    state.isBreakAllowed = parseConditionsList(
+      readIniString(ini, section, "allow_break", false, "", defaults.isBreakAllowed)
+    );
+    state.isMeetOnTalking = parseConditionsList(
+      readIniString(ini, section, "meet_on_talking", false, "", defaults.isMeetOnTalking)
+    );
+    state.useText = parseConditionsList(readIniString(ini, section, "use_text", false, "", defaults.useText));
+
+    state.resetDistance = logicsConfig.MEET_RESET_DISTANCE;
+    state.isMeetOnlyAtPathEnabled = true;
   }
 
   state.meetManager.initialize();

--- a/src/engine/core/schemes/mob_combat/SchemeMobCombat.ts
+++ b/src/engine/core/schemes/mob_combat/SchemeMobCombat.ts
@@ -4,7 +4,7 @@ import { ISchemeMobCombatState } from "@/engine/core/schemes/mob_combat/ISchemeM
 import { MobCombatManager } from "@/engine/core/schemes/mob_combat/MobCombatManager";
 import { getConfigSwitchConditions } from "@/engine/core/utils/ini/ini_config";
 import { LuaLogger } from "@/engine/core/utils/logging";
-import { ClientObject, EScheme, ESchemeType, IniFile, TSection } from "@/engine/lib/types";
+import { ClientObject, EScheme, ESchemeType, IniFile, Optional, TSection } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 
@@ -37,8 +37,11 @@ export class SchemeMobCombat extends AbstractScheme {
   }
 
   public static override disable(object: ClientObject, scheme: EScheme): void {
-    const state: ISchemeMobCombatState = registry.objects.get(object.id())[scheme] as ISchemeMobCombatState;
+    const state: Optional<ISchemeMobCombatState> = registry.objects.get(object.id())[scheme] as ISchemeMobCombatState;
 
-    state.enabled = false;
+    // No guarantee that it was activated before so should be checked additionally.
+    if (state !== null) {
+      state.enabled = false;
+    }
   }
 }

--- a/src/engine/core/ui/debug/sections/DebugGeneralSection.ts
+++ b/src/engine/core/ui/debug/sections/DebugGeneralSection.ts
@@ -12,7 +12,7 @@ const logger: LuaLogger = new LuaLogger($filename);
 const base: TPath = "menu\\debug\\DebugGeneralSection.component";
 
 /**
- * todo;
+ * Section of debug menu to handle generic information / generic actions.
  */
 @LuabindClass()
 export class DebugGeneralSection extends AbstractDebugSection {

--- a/src/engine/core/ui/interaction/SleepDialog.ts
+++ b/src/engine/core/ui/interaction/SleepDialog.ts
@@ -147,9 +147,9 @@ export class SleepDialog extends CUIScriptWnd {
   }
 
   /**
-   * todo;
+   * Show in-game sleep dialog options.
    */
-  public testAndShow(): void {
+  public showSleepOptions(): void {
     logger.info("Show sleep options");
 
     const actor: ClientObject = registry.actor;
@@ -217,8 +217,3 @@ export class SleepDialog extends CUIScriptWnd {
     disableInfo(infoPortions.sleep_active);
   }
 }
-
-// @ts-ignore Todo: Get rid of globals
-main = () => {
-  logger.info("[main] Call sleep from main");
-};

--- a/src/engine/core/utils/object/index.ts
+++ b/src/engine/core/utils/object/index.ts
@@ -1,3 +1,4 @@
+export * from "@/engine/core/utils/object/object_action";
 export * from "@/engine/core/utils/object/object_alife";
 export * from "@/engine/core/utils/object/object_anomaly";
 export * from "@/engine/core/utils/object/object_check";
@@ -8,6 +9,7 @@ export * from "@/engine/core/utils/object/object_get";
 export * from "@/engine/core/utils/object/object_info_portion";
 export * from "@/engine/core/utils/object/object_location";
 export * from "@/engine/core/utils/object/object_loot";
+export * from "@/engine/core/utils/object/object_meeting";
 export * from "@/engine/core/utils/object/object_section";
 export * from "@/engine/core/utils/object/object_set";
 export * from "@/engine/core/utils/object/object_sound";

--- a/src/engine/core/utils/object/object_action.test.ts
+++ b/src/engine/core/utils/object/object_action.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { level } from "xray16";
+
+import { registerActor, registry } from "@/engine/core/database";
+import { ActorInputManager } from "@/engine/core/managers/interface";
+import { objectPunchActor } from "@/engine/core/utils/object/object_action";
+import { animations } from "@/engine/lib/constants/animation/animations";
+import { ClientObject, EActiveItemSlot } from "@/engine/lib/types";
+import { resetFunctionMock } from "@/fixtures/utils";
+import { mockActorClientGameObject, mockClientGameObject } from "@/fixtures/xray";
+
+describe("object_action utils", () => {
+  beforeEach(() => {
+    resetFunctionMock(level.add_cam_effector);
+    registry.managers = new LuaTable();
+  });
+
+  it("'objectPunchActor' should correctly punch actor and force weapon drop based", () => {
+    const ak74: ClientObject = mockClientGameObject({ sectionOverride: "wpn_ak74" });
+    const actor: ClientObject = mockActorClientGameObject({
+      active_item: () => actor.object(ak74.section()),
+      active_slot: <T extends number>() => EActiveItemSlot.PRIMARY as T,
+      inventory: [[ak74.section(), ak74]],
+    });
+    const object: ClientObject = mockClientGameObject();
+
+    registerActor(actor);
+
+    jest.spyOn(actor.position(), "distance_to_sqr").mockImplementation(() => 4.1);
+    jest.spyOn(ActorInputManager.getInstance(), "setInactiveInputTime").mockImplementation(() => {});
+
+    objectPunchActor(object);
+
+    expect(level.add_cam_effector).not.toHaveBeenCalled();
+    expect(ActorInputManager.getInstance().setInactiveInputTime).not.toHaveBeenCalled();
+    expect(actor.drop_item).not.toHaveBeenCalled();
+    expect(actor.object(ak74.section())).toBe(ak74);
+
+    jest
+      .spyOn(actor.position(), "distance_to_sqr")
+      .mockReset()
+      .mockImplementation(() => 4);
+
+    objectPunchActor(object);
+
+    expect(level.add_cam_effector).toHaveBeenCalledWith(animations.camera_effects_fusker, 999, false, "");
+    expect(ActorInputManager.getInstance().setInactiveInputTime).toHaveBeenCalled();
+    expect(actor.drop_item).toHaveBeenCalled();
+    expect(actor.object(ak74.section())).toBeNull();
+
+    objectPunchActor(object);
+
+    expect(level.add_cam_effector).toHaveBeenCalledTimes(2);
+    expect(ActorInputManager.getInstance().setInactiveInputTime).toHaveBeenCalledTimes(2);
+    expect(actor.drop_item).toHaveBeenCalledTimes(1);
+    expect(actor.object(ak74.section())).toBeNull();
+  });
+
+  it("'objectPunchActor' should not drop items when active slot is not primary or secondary", () => {
+    const actor: ClientObject = mockActorClientGameObject({
+      active_item: () => mockClientGameObject(),
+      inventory: [["wpn_ak74", mockClientGameObject({ sectionOverride: "wpn_ak74" })]],
+    });
+    const object: ClientObject = mockClientGameObject();
+
+    registerActor(actor);
+
+    jest.spyOn(actor.position(), "distance_to_sqr").mockImplementation(() => 4);
+    jest.spyOn(actor, "active_slot").mockImplementation(() => EActiveItemSlot.NONE);
+
+    objectPunchActor(object);
+
+    expect(actor.drop_item).not.toHaveBeenCalled();
+
+    jest.spyOn(actor, "active_slot").mockImplementation(() => EActiveItemSlot.KNIFE);
+
+    objectPunchActor(object);
+
+    expect(actor.drop_item).not.toHaveBeenCalled();
+
+    jest.spyOn(actor, "active_slot").mockImplementation(() => EActiveItemSlot.SECONDARY);
+
+    objectPunchActor(object);
+
+    expect(actor.drop_item).toHaveBeenCalled();
+
+    jest.spyOn(actor, "active_slot").mockImplementation(() => EActiveItemSlot.PRIMARY);
+
+    objectPunchActor(object);
+
+    expect(actor.drop_item).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/engine/core/utils/object/object_action.ts
+++ b/src/engine/core/utils/object/object_action.ts
@@ -1,0 +1,33 @@
+import { level } from "xray16";
+
+import { registry } from "@/engine/core/database";
+import { ActorInputManager } from "@/engine/core/managers/interface/ActorInputManager";
+import { animations } from "@/engine/lib/constants/animation/animations";
+import { ClientObject, EActiveItemSlot, Optional } from "@/engine/lib/types";
+
+/**
+ * Punch actor as object.
+ *
+ * @param object - client object that should hit actor
+ */
+export function objectPunchActor(object: ClientObject): void {
+  const actor: ClientObject = registry.actor;
+
+  // Too far to hit.
+  if (actor.position().distance_to_sqr(object.position()) > 4) {
+    return;
+  }
+
+  ActorInputManager.getInstance().setInactiveInputTime(30);
+  level.add_cam_effector(animations.camera_effects_fusker, 999, false, "");
+
+  const activeSlot: EActiveItemSlot = actor.active_slot();
+
+  if (activeSlot === EActiveItemSlot.PRIMARY || activeSlot === EActiveItemSlot.SECONDARY) {
+    const activeItem: Optional<ClientObject> = actor.active_item();
+
+    if (activeItem) {
+      actor.drop_item(activeItem);
+    }
+  }
+}

--- a/src/engine/core/utils/object/object_meeting.test.ts
+++ b/src/engine/core/utils/object/object_meeting.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { IRegistryObjectState, registerObject } from "@/engine/core/database";
+import { addObjectAbuse, clearObjectAbuse, setObjectAbuseState } from "@/engine/core/utils/object/object_meeting";
+import { AnyObject, ClientObject, EScheme } from "@/engine/lib/types";
+import { mockSchemeState } from "@/fixtures/engine";
+import { mockClientGameObject } from "@/fixtures/xray";
+
+describe("object_meeting utils", () => {
+  it("'addObjectAbuse' should correctly add abuse values to the manager", () => {
+    const object: ClientObject = mockClientGameObject();
+    const state: IRegistryObjectState = registerObject(object);
+    const manager = { addAbuse: jest.fn() };
+
+    state[EScheme.ABUSE] = mockSchemeState(object, EScheme.ABUSE, {
+      abuseManager: manager,
+    } as AnyObject);
+
+    addObjectAbuse(object, 10);
+    expect(manager.addAbuse).toHaveBeenCalledWith(10);
+
+    addObjectAbuse(object, 20);
+    expect(manager.addAbuse).toHaveBeenCalledTimes(2);
+  });
+
+  it("'clearObjectAbuse' should correctly clear abuse state from the manager", () => {
+    const object: ClientObject = mockClientGameObject();
+    const state: IRegistryObjectState = registerObject(object);
+    const manager = { clearAbuse: jest.fn() };
+
+    state[EScheme.ABUSE] = mockSchemeState(object, EScheme.ABUSE, {
+      abuseManager: manager,
+    } as AnyObject);
+
+    clearObjectAbuse(object);
+    expect(manager.clearAbuse).toHaveBeenCalled();
+
+    clearObjectAbuse(object);
+    expect(manager.clearAbuse).toHaveBeenCalledTimes(2);
+  });
+
+  it("'setObjectAbuseState' should correctly set abuse state for the manager", () => {
+    const object: ClientObject = mockClientGameObject();
+    const state: IRegistryObjectState = registerObject(object);
+    const manager = { enableAbuse: jest.fn(), disableAbuse: jest.fn() };
+
+    state[EScheme.ABUSE] = mockSchemeState(object, EScheme.ABUSE, {
+      abuseManager: manager,
+    } as AnyObject);
+
+    setObjectAbuseState(object, true);
+    expect(manager.enableAbuse).toHaveBeenCalledTimes(1);
+
+    setObjectAbuseState(object, false);
+    expect(manager.disableAbuse).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/engine/core/utils/object/object_meeting.ts
+++ b/src/engine/core/utils/object/object_meeting.ts
@@ -1,0 +1,42 @@
+import { registry } from "@/engine/core/database";
+import { ISchemeAbuseState } from "@/engine/core/schemes/abuse";
+import { ClientObject, EScheme, Optional, TCount } from "@/engine/lib/types";
+
+/**
+ * Increment abuse for object.
+ *
+ * @param object - target client object
+ * @param value - count of abuse to add
+ */
+export function addObjectAbuse(object: ClientObject, value: TCount): void {
+  const abuseState: Optional<ISchemeAbuseState> = registry.objects.get(object.id())[EScheme.ABUSE] as ISchemeAbuseState;
+
+  abuseState?.abuseManager.addAbuse(value);
+}
+
+/**
+ * Clear abuse state for object.
+ *
+ * @param object - target client object
+ */
+export function clearObjectAbuse(object: ClientObject): void {
+  const state: Optional<ISchemeAbuseState> = registry.objects.get(object.id())[EScheme.ABUSE] as ISchemeAbuseState;
+
+  state?.abuseManager.clearAbuse();
+}
+
+/**
+ * Set object abuse state.
+ *
+ * @param object - target client object
+ * @param isEnabled - whether object abuse state should be enabled
+ */
+export function setObjectAbuseState(object: ClientObject, isEnabled: boolean): void {
+  const state: Optional<ISchemeAbuseState> = registry.objects.get(object.id())[EScheme.ABUSE] as ISchemeAbuseState;
+
+  if (isEnabled) {
+    state?.abuseManager.enableAbuse();
+  } else {
+    state?.abuseManager.disableAbuse();
+  }
+}

--- a/src/engine/lib/constants/items/index.ts
+++ b/src/engine/lib/constants/items/index.ts
@@ -1,31 +1,16 @@
-import { TAmmoItem, TAmmoItems } from "@/engine/lib/constants/items/ammo";
-import { TArtefact, TArtefacts } from "@/engine/lib/constants/items/artefacts";
-import { TDetector, TDetectors } from "@/engine/lib/constants/items/detectors";
-import { TDrugItem, TDrugItems } from "@/engine/lib/constants/items/drugs";
-import { TFoodItem, TFoodItems } from "@/engine/lib/constants/items/food";
-import { THelmet, THelmets } from "@/engine/lib/constants/items/helmets";
-import { TOutfit, TOutfits } from "@/engine/lib/constants/items/outfits";
-import { TQuestItem, TQuestItems } from "@/engine/lib/constants/items/quest_items";
-import { TWeaponAddon, TWeaponAddons } from "@/engine/lib/constants/items/weapon_addons";
-import { TWeapon, TWeapons } from "@/engine/lib/constants/items/weapons";
+import { TAmmoItem } from "@/engine/lib/constants/items/ammo";
+import { TArtefact } from "@/engine/lib/constants/items/artefacts";
+import { TDetector } from "@/engine/lib/constants/items/detectors";
+import { TDrugItem } from "@/engine/lib/constants/items/drugs";
+import { TFoodItem } from "@/engine/lib/constants/items/food";
+import { THelmet } from "@/engine/lib/constants/items/helmets";
+import { TOutfit } from "@/engine/lib/constants/items/outfits";
+import { TQuestItem } from "@/engine/lib/constants/items/quest_items";
+import { TWeaponAddon } from "@/engine/lib/constants/items/weapon_addons";
+import { TWeapon } from "@/engine/lib/constants/items/weapons";
 
 /**
- * todo;
- */
-export type TInventoryItems =
-  | TAmmoItems
-  | TArtefacts
-  | TDetectors
-  | TDrugItems
-  | TFoodItems
-  | THelmets
-  | TOutfits
-  | TWeaponAddons
-  | TWeapons
-  | TQuestItems;
-
-/**
- * todo;
+ * Type definition of possible item section.
  */
 export type TInventoryItem =
   | TAmmoItem

--- a/src/engine/lib/constants/sections.ts
+++ b/src/engine/lib/constants/sections.ts
@@ -9,3 +9,8 @@ export const SMART_TERRAIN_SECTION: TName = "smart_terrain";
  * Section representing stalkers that are used only for cutscenes / scenarios (todo: confirm).
  */
 export const ACTOR_VISUAL_STALKER: TName = "actor_visual_stalker";
+
+/**
+ * Section to disable meet scheme.
+ */
+export const NO_MEET_SECTION: TName = "no_meet";

--- a/src/engine/lib/constants/textures/file_textures.ts
+++ b/src/engine/lib/constants/textures/file_textures.ts
@@ -1,7 +1,7 @@
 /* eslint sort-keys-fix/sort-keys-fix: "error" */
 
 /**
- * todo;
+ * List of possible game textures used in original COP.
  */
 export const fileTextures = {
   $alphadxt1: "$alphadxt1",

--- a/src/engine/lib/types/game.ts
+++ b/src/engine/lib/types/game.ts
@@ -1,0 +1,9 @@
+/**
+ * Enum describing active item slot.
+ */
+export enum EActiveItemSlot {
+  NONE = 0,
+  KNIFE = 1,
+  SECONDARY = 2,
+  PRIMARY = 3,
+}

--- a/src/engine/lib/types/index.ts
+++ b/src/engine/lib/types/index.ts
@@ -1,4 +1,5 @@
 export * from "@/engine/lib/types/alias";
+export * from "@/engine/lib/types/game";
 export * from "@/engine/lib/types/scheme";
 export * from "@/engine/lib/types/general";
 export * from "@/engine/lib/types/ui";

--- a/src/engine/lib/types/scheme.ts
+++ b/src/engine/lib/types/scheme.ts
@@ -1,5 +1,3 @@
-import type { PartialRecord } from "@/engine/lib/types/general";
-
 /**
  * Section name string, representing string256 in c++.
  */

--- a/src/engine/scripts/declarations/callbacks/game.test.ts
+++ b/src/engine/scripts/declarations/callbacks/game.test.ts
@@ -8,6 +8,7 @@ describe("'game' external callbacks", () => {
   });
 
   it("should correctly inject external methods for game", () => {
+    checkBinding("main");
     checkBinding("smart_covers");
     checkNestedBinding("smart_covers", "descriptions");
     checkBinding("outro");

--- a/src/engine/scripts/declarations/callbacks/game.ts
+++ b/src/engine/scripts/declarations/callbacks/game.ts
@@ -11,6 +11,12 @@ const logger: LuaLogger = new LuaLogger($filename);
 logger.info("Resolve and bind game externals");
 
 /**
+ * Declare `main` function to enable custom scripts execution.
+ * In case if custom script is executed from console and has no `main` function, this placeholder will be used.
+ */
+extern("main", () => {});
+
+/**
  * Declare list of available smart covers for game engine.
  * Xray uses it internally.
  */

--- a/src/engine/scripts/declarations/effects/object.ts
+++ b/src/engine/scripts/declarations/effects/object.ts
@@ -27,6 +27,7 @@ import {
 } from "@/engine/core/utils/ini";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { getObjectSmartTerrain } from "@/engine/core/utils/object";
+import { clearObjectAbuse } from "@/engine/core/utils/object/object_meeting";
 import {
   releaseObject,
   spawnItemsForObject,
@@ -203,10 +204,10 @@ extern("xr_effects.remove_npc", (actor: ClientObject, npc: ClientObject, p: [Opt
 });
 
 /**
- * todo;
+ * Clear abuse for provided object.
  */
-extern("xr_effects.clear_abuse", (object: ClientObject) => {
-  SchemeAbuse.clearAbuse(object);
+extern("xr_effects.clear_abuse", (actor: ClientObject, object: ClientObject) => {
+  clearObjectAbuse(object);
 });
 
 /**

--- a/src/fixtures/xray/mocks/interface/levelInterface.mock.ts
+++ b/src/fixtures/xray/mocks/interface/levelInterface.mock.ts
@@ -12,6 +12,7 @@ export const CLIENT_SIDE_REGISTRY: MockLuaTable<TNumberId, ClientObject> = MockL
  * Mock game `level` interface.
  */
 export const mockLevelInterface = {
+  add_cam_effector: jest.fn(),
   add_pp_effector: jest.fn(),
   disable_input: jest.fn(),
   get_game_difficulty: jest.fn(() => 3),

--- a/src/fixtures/xray/mocks/objects/client/game_object.mock.ts
+++ b/src/fixtures/xray/mocks/objects/client/game_object.mock.ts
@@ -140,6 +140,13 @@ export function mockClientGameObject({
           return false;
         }
       }),
+    drop_item:
+      rest.drop_item ||
+      jest.fn((it: ClientObject) => {
+        if (inventoryMap.get(it.section())) {
+          inventoryMap.delete(it.section());
+        }
+      }),
     force_set_goodwill: rest.force_set_goodwill || jest.fn(),
     game_vertex_id,
     general_goodwill:
@@ -333,6 +340,15 @@ export function mockClientGameObject({
 /**
  * Mock client game object.
  */
-export function mockActorClientGameObject(base: Partial<ClientObject> = {}): ClientObject {
+export function mockActorClientGameObject(
+  base: Partial<
+    ClientObject & {
+      idOverride?: TNumberId;
+      sectionOverride?: TSection;
+      infoPortions?: Array<TName>;
+      inventory: Array<[TSection | TNumberId, ClientObject]>;
+    }
+  > = {}
+): ClientObject {
   return mockClientGameObject({ ...base, idOverride: ACTOR_ID });
 }


### PR DESCRIPTION
## Changelist
- Fix issue when custom scripts called 'main' from sleep dialog file
- EActiveItemSlot  enum added for slots
- Added separate functions to manage abuse state / punch in utils. Added related tests
- Split scheme meet section, add tests for some utils. Naming / parameters updated to match TS codestyle