### PR TITLE
[SCHEMES] Merging scheme reset and scheme activate events. Similar naming for s…

### DIFF
--- a/src/engine/core/database/logic.ts
+++ b/src/engine/core/database/logic.ts
@@ -4,7 +4,7 @@ import { loadPortableStore, savePortableStore } from "@/engine/core/database/por
 import { registry } from "@/engine/core/database/registry";
 import { closeLoadMarker, closeSaveMarker, openLoadMarker, openSaveMarker } from "@/engine/core/database/save_markers";
 import { IRegistryObjectState } from "@/engine/core/database/types";
-import { ESchemeEvent, IBaseSchemeState } from "@/engine/core/objects/ai/scheme/types";
+import { ESchemeEvent, IBaseSchemeState } from "@/engine/core/objects/ai/scheme/scheme_types";
 import { readTimeFromPacket, writeTimeToPacket } from "@/engine/core/utils/game/game_time";
 import { emitSchemeEvent } from "@/engine/core/utils/scheme/scheme_event";
 import { NIL } from "@/engine/lib/constants/words";

--- a/src/engine/core/objects/ai/scheme/AbstractScheme.ts
+++ b/src/engine/core/objects/ai/scheme/AbstractScheme.ts
@@ -1,5 +1,5 @@
 import { IRegistryObjectState, registry } from "@/engine/core/database";
-import { IBaseSchemeState } from "@/engine/core/objects/ai/scheme/types";
+import { IBaseSchemeState, ISchemeEventHandler } from "@/engine/core/objects/ai/scheme/scheme_types";
 import { abort } from "@/engine/core/utils/assertion";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { AnyObject, ClientObject, IniFile, Optional, TName } from "@/engine/lib/types";
@@ -107,11 +107,7 @@ export abstract class AbstractScheme {
   /**
    * todo: Description.
    */
-  public static subscribe(
-    object: ClientObject,
-    state: IBaseSchemeState,
-    subscriber: TName | AnyObject | LuaTable
-  ): void {
+  public static subscribe(object: ClientObject, state: IBaseSchemeState, subscriber: ISchemeEventHandler): void {
     if (!state.actions) {
       state.actions = new LuaTable();
     }

--- a/src/engine/core/objects/ai/scheme/AbstractSchemeManager.ts
+++ b/src/engine/core/objects/ai/scheme/AbstractSchemeManager.ts
@@ -1,11 +1,12 @@
-import { IBaseSchemeState, ISchemeEventHandler } from "@/engine/core/objects/ai/scheme/types";
+import { IBaseSchemeState, ISchemeEventHandler } from "@/engine/core/objects/ai/scheme/scheme_types";
 import { LuaLogger } from "@/engine/core/utils/logging";
 import { ClientObject, Optional, TCount, TIndex, TName, Vector } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 
 /**
- * todo;
+ * Abstract scheme manager class representing unit that works when scheme is active.
+ * Includes generic handlers and interface for implementation of scheme events.
  */
 export abstract class AbstractSchemeManager<T extends IBaseSchemeState> implements ISchemeEventHandler {
   public readonly object: ClientObject;
@@ -16,36 +17,22 @@ export abstract class AbstractSchemeManager<T extends IBaseSchemeState> implemen
     this.state = state;
   }
 
-  public activateScheme(isLoading: boolean, object: ClientObject): void {
-    logger.info("Activate scheme:", this.state?.scheme, this.object.name());
-  }
-
-  public resetScheme(): void {
+  public activate(isLoading: boolean, object: ClientObject): void {
     // logger.info("Reset scheme:", this.state?.scheme, this.object.name());
   }
 
-  public deactivate(): void {
+  public deactivate(object: ClientObject): void {
     // logger.info("Deactivate:", this.state?.scheme, this.object.name());
   }
 
-  public net_spawn(): void {
-    logger.info("Net spawn:", this.state?.scheme, this.object.name());
+  public onSwitchOnline(object: ClientObject): void {
+    logger.info("Net spawn:", this.state?.scheme, object.name());
   }
 
-  public net_destroy(): void {
-    logger.info("Net destroy:", this.state?.scheme, this.object.name());
+  public onSwitchOffline(object: ClientObject): void {
+    logger.info("Net destroy:", this.state?.scheme, object.name());
   }
 
-  /**
-   * Handle scheme hit callback.
-   * Emits when objects are hit by something.
-   *
-   * @param object - target client object being hit
-   * @param amount - amount of hit applied
-   * @param direction - direction of hit
-   * @param who - client object which is source of hit
-   * @param boneIndex - index of bone being hit
-   */
   public onHit(
     object: ClientObject,
     amount: TCount,
@@ -64,14 +51,7 @@ export abstract class AbstractSchemeManager<T extends IBaseSchemeState> implemen
     logger.info("Waypoint:", this.state?.scheme, this.object.name());
   }
 
-  /**
-   * Handle scheme death callback.
-   * Emits when objects are dying.
-   *
-   * @param object - target client object dying
-   * @param who - client object who killed the object
-   */
-  public onDeath(object: ClientObject, who: Optional<ClientObject>): void {
+  public onDeath(victim: ClientObject, who: Optional<ClientObject>): void {
     logger.info("Death:", this.state?.scheme, this.object.name());
   }
 

--- a/src/engine/core/objects/ai/scheme/index.ts
+++ b/src/engine/core/objects/ai/scheme/index.ts
@@ -1,3 +1,3 @@
 export * from "@/engine/core/objects/ai/scheme/AbstractScheme";
 export * from "@/engine/core/objects/ai/scheme/AbstractSchemeManager";
-export * from "@/engine/core/objects/ai/scheme/types";
+export * from "@/engine/core/objects/ai/scheme/scheme_types";

--- a/src/engine/core/objects/ai/scheme/scheme_types.ts
+++ b/src/engine/core/objects/ai/scheme/scheme_types.ts
@@ -56,20 +56,19 @@ export interface IBaseSchemeState {
 }
 
 /**
- * todo;
- * todo: Implement net spawn, rename netDestroy
+ * Generic scheme logics events to get callbacks from schemeManager subscribers.
  */
 export enum ESchemeEvent {
-  ACTIVATE_SCHEME = "activateScheme",
-  DEACTIVATE = "deactivate", // todo: Rename to deactivate scheme
+  ACTIVATE = "activate",
+  DEACTIVATE = "deactivate",
+  SAVE = "save",
+  UPDATE = "update",
   DEATH = "onDeath",
   CUTSCENE = "onCutscene",
   EXTRAPOLATE = "onExtrapolate",
-  NET_DESTROY = "net_destroy",
+  SWITCH_ONLINE = "onSwitchOnline",
+  SWITCH_OFFLINE = "onSwitchOffline",
   HIT = "onHit",
-  RESET_SCHEME = "resetScheme", // todo: Probably merge with activate scheme or rename it to activateRestrictorScheme
-  SAVE = "save",
-  UPDATE = "update",
   USE = "onUse",
   WAYPOINT = "onWaypoint",
 }
@@ -80,31 +79,38 @@ export enum ESchemeEvent {
  */
 export interface ISchemeEventHandler {
   /**
+   * todo: Description, swap params order.
+   */
+  activate?(isLoading: boolean, object: ClientObject): void;
+  /**
+   * todo: Description.
+   */
+  deactivate?(object: ClientObject): void;
+  /**
    * todo: Description.
    */
   update?(delta: TCount): void;
   /**
-   * todo: Description, swap params order.
+   * todo: Description.
    */
-  activateScheme?(isLoading: boolean, object: ClientObject): void;
-  /**
-   * todo: Description, swap params order.
-   */
-  resetScheme?(isLoading: boolean, object: ClientObject): void;
+  save?(delta: TCount): void;
   /**
    * todo: Description.
    */
-  deactivate?(): void;
+  onSwitchOnline?(object: ClientObject): void;
   /**
    * todo: Description.
    */
-  net_spawn?(): void;
+  onSwitchOffline?(object: ClientObject): void;
   /**
-   * todo: Description.
-   */
-  net_destroy?(object: ClientObject): void;
-  /**
-   * todo: Description.
+   * Handle scheme hit callback.
+   * Emits when objects are hit by something.
+   *
+   * @param object - target client object being hit
+   * @param amount - amount of hit applied
+   * @param direction - direction of hit
+   * @param who - client object which is source of hit
+   * @param boneIndex - index of bone being hit
    */
   onHit?(object: ClientObject, amount: TCount, direction: Vector, who: Optional<ClientObject>, boneIndex: TIndex): void;
   /**
@@ -116,7 +122,11 @@ export interface ISchemeEventHandler {
    */
   onWaypoint?(object: ClientObject, actionType: TName, index: TIndex): void;
   /**
-   * todo: Description.
+   * Handle scheme death callback.
+   * Emits when objects are dying.
+   *
+   * @param victim - target client object dying
+   * @param who - client object who killed the object
    */
   onDeath?(victim: ClientObject, who: Optional<ClientObject>): void;
   /**

--- a/src/engine/core/objects/binders/creature/MonsterBinder.ts
+++ b/src/engine/core/objects/binders/creature/MonsterBinder.ts
@@ -204,7 +204,7 @@ export class MonsterBinder extends object_binder {
     registry.actorCombat.delete(this.object.id());
 
     if (this.state.activeScheme !== null) {
-      emitSchemeEvent(this.object, this.state[this.state.activeScheme]!, ESchemeEvent.NET_DESTROY, this.object);
+      emitSchemeEvent(this.object, this.state[this.state.activeScheme]!, ESchemeEvent.SWITCH_OFFLINE, this.object);
     }
 
     const offlineObject: IStoredOfflineObject = registry.offlineObjects.get(this.object.id());

--- a/src/engine/core/objects/binders/creature/StalkerBinder.ts
+++ b/src/engine/core/objects/binders/creature/StalkerBinder.ts
@@ -233,11 +233,11 @@ export class StalkerBinder extends object_binder {
     const state: IRegistryObjectState = registry.objects.get(objectId);
 
     if (state.activeScheme) {
-      emitSchemeEvent(this.object, state[state.activeScheme]!, ESchemeEvent.NET_DESTROY, this.object);
+      emitSchemeEvent(this.object, state[state.activeScheme]!, ESchemeEvent.SWITCH_OFFLINE, this.object);
     }
 
     if (this.state[EScheme.REACH_TASK]) {
-      emitSchemeEvent(this.object, this.state[EScheme.REACH_TASK], ESchemeEvent.NET_DESTROY, this.object);
+      emitSchemeEvent(this.object, this.state[EScheme.REACH_TASK], ESchemeEvent.SWITCH_OFFLINE, this.object);
     }
 
     // Call logics on offline.

--- a/src/engine/core/objects/binders/physic/PhysicObjectBinder.ts
+++ b/src/engine/core/objects/binders/physic/PhysicObjectBinder.ts
@@ -64,7 +64,7 @@ export class PhysicObjectBinder extends object_binder {
     const state: IRegistryObjectState = registry.objects.get(this.object.id());
 
     if (state.activeScheme) {
-      emitSchemeEvent(this.object, state[state.activeScheme]!, ESchemeEvent.NET_DESTROY, this.object);
+      emitSchemeEvent(this.object, state[state.activeScheme]!, ESchemeEvent.SWITCH_OFFLINE, this.object);
     }
 
     const on_offline_condlist: Optional<TConditionList> = state?.overrides?.on_offline_condlist;

--- a/src/engine/core/objects/binders/zones/RestrictorBinder.ts
+++ b/src/engine/core/objects/binders/zones/RestrictorBinder.ts
@@ -60,7 +60,7 @@ export class RestrictorBinder extends object_binder {
     const state: IRegistryObjectState = this.state;
 
     if (state.activeScheme !== null) {
-      emitSchemeEvent(this.object, state[state.activeScheme!]!, ESchemeEvent.NET_DESTROY, this.object);
+      emitSchemeEvent(this.object, state[state.activeScheme!]!, ESchemeEvent.SWITCH_OFFLINE, this.object);
     }
 
     unregisterZone(this.object);

--- a/src/engine/core/schemes/animpoint/AnimpointManager.ts
+++ b/src/engine/core/schemes/animpoint/AnimpointManager.ts
@@ -39,7 +39,7 @@ export class AnimpointManager extends AbstractSchemeManager<ISchemeAnimpointStat
   public smartCoverDirection: Optional<Vector> = null;
   public lookPosition: Optional<Vector> = null;
 
-  public override activateScheme(isLoading: boolean, object: ClientObject): void {
+  public override activate(isLoading: boolean, object: ClientObject): void {
     logger.info("Activate animpoint scheme:", object.name());
 
     this.state.signals = new LuaTable();

--- a/src/engine/core/schemes/animpoint/SchemeAnimpoint.ts
+++ b/src/engine/core/schemes/animpoint/SchemeAnimpoint.ts
@@ -90,8 +90,6 @@ export class SchemeAnimpoint extends AbstractScheme {
 
     planner.add_action(EActionId.ANIMPOINT_REACH, actionReachAnimpoint);
 
-    SchemeAnimpoint.subscribe(object, schemeState, actionReachAnimpoint);
-
     const actionAnimpoint: ActionAnimpoint = new ActionAnimpoint(schemeState);
 
     addCommonActionPreconditions(actionAnimpoint);

--- a/src/engine/core/schemes/animpoint/actions/ActionAnimpoint.ts
+++ b/src/engine/core/schemes/animpoint/actions/ActionAnimpoint.ts
@@ -42,13 +42,6 @@ export class ActionAnimpoint extends action_base implements ISchemeEventHandler 
   }
 
   /**
-   * Stop animation on net destroy.
-   */
-  public net_destroy(): void {
-    this.state.animpointManager.stop();
-  }
-
-  /**
    * On animation execution start, perform animations scenario.
    */
   public override execute(): void {
@@ -68,5 +61,12 @@ export class ActionAnimpoint extends action_base implements ISchemeEventHandler 
       { lookPosition: this.state.animpointManager.lookPosition, lookObjectId: null },
       { animationPosition: position, animationDirection: direction }
     );
+  }
+
+  /**
+   * Stop animation on net destroy.
+   */
+  public onSwitchOffline(): void {
+    this.state.animpointManager.stop();
   }
 }

--- a/src/engine/core/schemes/camper/actions/ActionCamperPatrol.ts
+++ b/src/engine/core/schemes/camper/actions/ActionCamperPatrol.ts
@@ -2,6 +2,7 @@ import { action_base, danger_object, LuabindClass, patrol, stalker_ids, time_glo
 
 import { registry, setStalkerState } from "@/engine/core/database";
 import { GlobalSoundManager } from "@/engine/core/managers/sounds/GlobalSoundManager";
+import { ISchemeEventHandler } from "@/engine/core/objects/ai/scheme";
 import { StalkerMoveManager } from "@/engine/core/objects/ai/state/StalkerMoveManager";
 import { EStalkerState, ILookTargetDescriptor } from "@/engine/core/objects/animation/types";
 import { ICampPoint, ISchemeCamperState } from "@/engine/core/schemes/camper/ISchemeCamperState";
@@ -9,13 +10,13 @@ import { abort } from "@/engine/core/utils/assertion";
 import { parseWaypointsData } from "@/engine/core/utils/ini";
 import { isObjectAtWaypoint, isObjectFacingDanger } from "@/engine/core/utils/object";
 import { createVector } from "@/engine/core/utils/vector";
-import { ClientObject, DangerObject, Optional, Vector } from "@/engine/lib/types";
+import { ClientObject, DangerObject, Optional, Patrol, Vector } from "@/engine/lib/types";
 
 /**
  * todo;
  */
 @LuabindClass()
-export class ActionCamperPatrol extends action_base {
+export class ActionCamperPatrol extends action_base implements ISchemeEventHandler {
   public state: ISchemeCamperState;
   public moveManager: StalkerMoveManager;
 
@@ -50,14 +51,21 @@ export class ActionCamperPatrol extends action_base {
     this.object.set_desired_position();
     this.object.set_desired_direction();
 
-    this.resetScheme();
+    this.reset();
     this.enemyPosition = null;
   }
 
   /**
    * todo: Description.
    */
-  public resetScheme(): void {
+  public activate(): void {
+    this.reset();
+  }
+
+  /**
+   * todo: Description.
+   */
+  public reset(): void {
     setStalkerState(this.object, EStalkerState.PATROL, null, null, null, null);
 
     this.state.signals = new LuaTable();
@@ -118,13 +126,6 @@ export class ActionCamperPatrol extends action_base {
     this.state.last_look_point = null;
     this.state.cur_look_point = null;
     this.state.scan_begin = null;
-  }
-
-  /**
-   * todo: Description.
-   */
-  public activateScheme(): void {
-    this.resetScheme();
   }
 
   /**
@@ -516,7 +517,7 @@ export class ActionCamperPatrol extends action_base {
       return false;
     }
 
-    const path = new patrol(this.state.path_walk);
+    const path: Patrol = new patrol(this.state.path_walk);
 
     if (path !== null) {
       for (const k of $range(0, path.count() - 1)) {

--- a/src/engine/core/schemes/companion/SchemeCompanion.ts
+++ b/src/engine/core/schemes/companion/SchemeCompanion.ts
@@ -62,8 +62,6 @@ export class SchemeCompanion extends AbstractScheme {
     actionCompanionActivity.add_effect(new world_property(EEvaluatorId.IS_STATE_LOGIC_ACTIVE, false));
     actionPlanner.add_action(EActionId.COMPANION_ACTIVITY, actionCompanionActivity);
 
-    SchemeCompanion.subscribe(object, state, actionCompanionActivity);
-
     actionPlanner.action(EActionId.ALIFE).add_precondition(new world_property(EEvaluatorId.NEED_COMPANION, false));
   }
 }

--- a/src/engine/core/schemes/cover/actions/ActionCover.ts
+++ b/src/engine/core/schemes/cover/actions/ActionCover.ts
@@ -61,7 +61,7 @@ export class ActionCover extends action_base implements ISchemeEventHandler {
    * Handle scheme activation event.
    * todo: Description.
    */
-  public activateScheme(): void {
+  public activate(): void {
     this.state.signals = new LuaTable();
 
     const smartTerrainVertexId: TNumberId = SimulationBoardManager.getInstance().getSmartTerrainByName(

--- a/src/engine/core/schemes/heli_move/HelicopterMoveManager.ts
+++ b/src/engine/core/schemes/heli_move/HelicopterMoveManager.ts
@@ -53,7 +53,7 @@ export class HelicopterMoveManager extends AbstractSchemeManager<ISchemeHelicopt
   /**
    * todo: Description.
    */
-  public override resetScheme(loading?: boolean): void {
+  public override activate(loading?: boolean): void {
     this.state.signals = new LuaTable();
     this.heliObject.TurnEngineSound(this.state.engine_sound);
 

--- a/src/engine/core/schemes/mob_home/MobHomeManager.test.ts
+++ b/src/engine/core/schemes/mob_home/MobHomeManager.test.ts
@@ -42,7 +42,7 @@ describe("MobHomeManager functionality", () => {
       );
     });
 
-    mobHomeManager.resetScheme();
+    mobHomeManager.activate();
 
     expect(mobHomeManager.getHomeParameters).toHaveBeenCalledTimes(1);
     expect(object.set_home).toHaveBeenCalledWith(

--- a/src/engine/core/schemes/mob_home/MobHomeManager.ts
+++ b/src/engine/core/schemes/mob_home/MobHomeManager.ts
@@ -20,7 +20,7 @@ export class MobHomeManager extends AbstractSchemeManager<ISchemeMobHomeState> {
   public static readonly DEFAULT_MID_RADIUS: TDistance = 20;
   public static readonly DEFAULT_MAX_RADIUS: TDistance = 70;
 
-  public override resetScheme(): void {
+  public override activate(): void {
     setMonsterState(this.object, this.state.monsterState);
 
     const [name, minRadius, maxRadius, isAggressive, midRadius] = this.getHomeParameters();

--- a/src/engine/core/schemes/mob_jump/MobJumpManager.ts
+++ b/src/engine/core/schemes/mob_jump/MobJumpManager.ts
@@ -22,7 +22,7 @@ export class MobJumpManager extends AbstractSchemeManager<ISchemeMobJumpState> {
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     scriptCaptureMonster(this.object, true, MobJumpManager.name);
 
     // -- reset signals

--- a/src/engine/core/schemes/mob_remark/MobRemarkManager.ts
+++ b/src/engine/core/schemes/mob_remark/MobRemarkManager.ts
@@ -20,7 +20,7 @@ export class MobRemarkManager extends AbstractSchemeManager<ISchemeMobRemarkStat
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     setMonsterState(this.object, this.state.state);
 
     this.object.disable_talk();

--- a/src/engine/core/schemes/mob_walker/MobWalkerManager.ts
+++ b/src/engine/core/schemes/mob_walker/MobWalkerManager.ts
@@ -56,7 +56,7 @@ export class MobWalkerManager extends AbstractSchemeManager<ISchemeMobWalkerStat
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     setMonsterState(this.object, this.state.state);
 
     this.state.signals = new LuaTable();
@@ -108,7 +108,7 @@ export class MobWalkerManager extends AbstractSchemeManager<ISchemeMobWalkerStat
    */
   public update(): void {
     if (!isMonsterScriptCaptured(this.object)) {
-      this.resetScheme();
+      this.activate();
 
       return;
     }

--- a/src/engine/core/schemes/patrol/actions/ActionCommander.ts
+++ b/src/engine/core/schemes/patrol/actions/ActionCommander.ts
@@ -2,6 +2,7 @@ import { action_base, LuabindClass } from "xray16";
 
 import { getStalkerState, registry } from "@/engine/core/database";
 import { GlobalSoundManager } from "@/engine/core/managers/sounds/GlobalSoundManager";
+import { ISchemeEventHandler } from "@/engine/core/objects/ai/scheme";
 import { StalkerMoveManager } from "@/engine/core/objects/ai/state/StalkerMoveManager";
 import { EStalkerState } from "@/engine/core/objects/animation/types";
 import { ISchemePatrolState } from "@/engine/core/schemes/patrol";
@@ -12,7 +13,7 @@ import { ClientObject, Optional } from "@/engine/lib/types";
  * Action to command patrol/group of stalker on way somewhere.
  */
 @LuabindClass()
-export class ActionCommander extends action_base {
+export class ActionCommander extends action_base implements ISchemeEventHandler {
   public readonly state: ISchemePatrolState;
   public readonly moveManager: StalkerMoveManager;
 
@@ -34,13 +35,13 @@ export class ActionCommander extends action_base {
     this.object.set_desired_position();
     this.object.set_desired_direction();
 
-    this.activateScheme();
+    this.activate();
   }
 
   /**
    * todo: Description.
    */
-  public activateScheme(): void {
+  public activate(): void {
     this.state.signals = new LuaTable();
 
     if (this.state.path_walk_info === null) {
@@ -142,7 +143,7 @@ export class ActionCommander extends action_base {
   /**
    * todo: Description.
    */
-  public net_destroy(object: ClientObject): void {
+  public onSwitchOffline(object: ClientObject): void {
     this.deactivate(object);
   }
 

--- a/src/engine/core/schemes/patrol/actions/ActionPatrol.ts
+++ b/src/engine/core/schemes/patrol/actions/ActionPatrol.ts
@@ -1,6 +1,7 @@
 import { action_base, LuabindClass, time_global } from "xray16";
 
 import { registry, setStalkerState } from "@/engine/core/database";
+import { ISchemeEventHandler } from "@/engine/core/objects/ai/scheme";
 import { StalkerMoveManager } from "@/engine/core/objects/ai/state/StalkerMoveManager";
 import { EStalkerState } from "@/engine/core/objects/animation/types";
 import { ISchemePatrolState } from "@/engine/core/schemes/patrol";
@@ -16,7 +17,7 @@ const logger: LuaLogger = new LuaLogger($filename);
  * Action patrol when objects should go to some specific place.
  */
 @LuabindClass()
-export class ActionPatrol extends action_base {
+export class ActionPatrol extends action_base implements ISchemeEventHandler {
   public readonly state: ISchemePatrolState;
   public readonly moveManager: StalkerMoveManager;
 
@@ -48,7 +49,7 @@ export class ActionPatrol extends action_base {
   /**
    * todo: Description.
    */
-  public activateScheme(): void {
+  public activate(): void {
     this.state.signals = new LuaTable();
 
     if (this.state.path_walk_info === null) {
@@ -124,21 +125,21 @@ export class ActionPatrol extends action_base {
   /**
    * todo: Description.
    */
-  public onDeath(npc: ClientObject): void {
-    registry.patrols.generic.get(this.state.patrol_key).removeNpc(npc);
+  public onDeath(object: ClientObject): void {
+    registry.patrols.generic.get(this.state.patrol_key).removeNpc(object);
   }
 
   /**
    * todo: Description.
    */
-  public deactivate(npc: ClientObject): void {
-    registry.patrols.generic.get(this.state.patrol_key).removeNpc(npc);
+  public deactivate(object: ClientObject): void {
+    registry.patrols.generic.get(this.state.patrol_key).removeNpc(object);
   }
 
   /**
    * todo: Description.
    */
-  public net_destroy(npc: ClientObject): void {
-    this.deactivate(npc);
+  public onSwitchOffline(object: ClientObject): void {
+    this.deactivate(object);
   }
 }

--- a/src/engine/core/schemes/ph_button/PhysicalButtonManager.ts
+++ b/src/engine/core/schemes/ph_button/PhysicalButtonManager.ts
@@ -17,7 +17,7 @@ const logger: LuaLogger = new LuaLogger($filename);
 export class PhysicalButtonManager extends AbstractSchemeManager<ISchemePhysicalButtonState> {
   public lastHitAt: Optional<TTimestamp> = null;
 
-  public override resetScheme(): void {
+  public override activate(): void {
     this.object.play_cycle(this.state.anim, this.state.blending);
 
     this.lastHitAt = time_global();

--- a/src/engine/core/schemes/ph_code/CodeManager.ts
+++ b/src/engine/core/schemes/ph_code/CodeManager.ts
@@ -12,7 +12,7 @@ export class CodeManager extends AbstractSchemeManager<ISchemeCodeState> {
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     this.object.set_nonscript_usable(false);
   }
 

--- a/src/engine/core/schemes/ph_door/PhysicalDoorManager.ts
+++ b/src/engine/core/schemes/ph_door/PhysicalDoorManager.ts
@@ -34,7 +34,7 @@ export class PhysicalDoorManager extends AbstractSchemeManager<ISchemePhysicalDo
   /**
    * todo: Description.
    */
-  public override resetScheme(loading?: boolean): void {
+  public override activate(loading?: boolean): void {
     this.state.signals = new LuaTable();
 
     this.isInitialized = false;

--- a/src/engine/core/schemes/ph_force/PhysicalForceManager.ts
+++ b/src/engine/core/schemes/ph_force/PhysicalForceManager.ts
@@ -15,7 +15,7 @@ export class PhysicalForceManager extends AbstractSchemeManager<ISchemePhysicalF
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     if (this.state.delay !== 0) {
       this.time = time_global() + this.state.delay;
     }

--- a/src/engine/core/schemes/ph_hit/PhysicalHitManager.ts
+++ b/src/engine/core/schemes/ph_hit/PhysicalHitManager.ts
@@ -10,7 +10,7 @@ import { Hit, Vector } from "@/engine/lib/types";
  * todo;
  */
 export class PhysicalHitManager extends AbstractSchemeManager<ISchemePhysicalHitState> {
-  public override resetScheme(): void {
+  public override activate(): void {
     const patrolPoint: Vector = new patrol(this.state.dir_path).point(0);
     const objectPosition: Vector = this.object.position();
 

--- a/src/engine/core/schemes/ph_idle/PhysicalIdleManager.ts
+++ b/src/engine/core/schemes/ph_idle/PhysicalIdleManager.ts
@@ -13,7 +13,7 @@ const logger: LuaLogger = new LuaLogger($filename);
  * Manager to handle idle state of physical objects.
  */
 export class PhysicalIdleManager extends AbstractSchemeManager<ISchemePhysicalIdleState> {
-  public override resetScheme(): void {
+  public override activate(): void {
     this.object.set_nonscript_usable(this.state.isNonscriptUsable);
   }
 

--- a/src/engine/core/schemes/ph_minigun/MinigunManager.ts
+++ b/src/engine/core/schemes/ph_minigun/MinigunManager.ts
@@ -79,7 +79,7 @@ export class MinigunManager extends AbstractSchemeManager<ISchemeMinigunState> {
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     this.startDelayingTime = time_global();
     this.startShootingTime = time_global();
 

--- a/src/engine/core/schemes/ph_oscillate/OscillateManager.ts
+++ b/src/engine/core/schemes/ph_oscillate/OscillateManager.ts
@@ -18,7 +18,7 @@ export class OscillateManager extends AbstractSchemeManager<ISchemeOscillateStat
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     this.time = time_global();
     this.dir = createVector(math.random(), 0, math.random()).normalize();
     this.coefficient = this.state.force / this.state.period;

--- a/src/engine/core/schemes/reach_task/SchemeReachTask.ts
+++ b/src/engine/core/schemes/reach_task/SchemeReachTask.ts
@@ -37,7 +37,9 @@ export class SchemeReachTask extends AbstractScheme {
     const manager: ActionPlanner = object.motivation_action_manager();
     const alifeAction: ActionBase = manager.action(EActionId.ALIFE);
     const alifeActionPlanner: ActionPlanner = cast_planner(alifeAction);
-    const smartTerrainTaskAction: ActionBase = alifeActionPlanner.action(EActionId.SMART_TERRAIN_TASK);
+    const smartTerrainTaskAction: ActionReachTaskLocation = alifeActionPlanner.action(
+      EActionId.SMART_TERRAIN_TASK
+    ) as ActionReachTaskLocation;
 
     SchemeReachTask.subscribe(object, state, smartTerrainTaskAction);
   }

--- a/src/engine/core/schemes/reach_task/actions/ActionReachTaskLocation.ts
+++ b/src/engine/core/schemes/reach_task/actions/ActionReachTaskLocation.ts
@@ -3,6 +3,7 @@ import { action_base, alife, anim, clsid, level, look, LuabindClass, move, objec
 import { registry } from "@/engine/core/database";
 import { TSimulationObject } from "@/engine/core/managers/simulation";
 import { SurgeManager } from "@/engine/core/managers/surge/SurgeManager";
+import { ISchemeEventHandler } from "@/engine/core/objects/ai/scheme";
 import { EStalkerState } from "@/engine/core/objects/animation/types";
 import { Squad } from "@/engine/core/objects/server/squad/Squad";
 import { ReachTaskPatrolManager } from "@/engine/core/schemes/reach_task/ReachTaskPatrolManager";
@@ -28,7 +29,7 @@ const logger: LuaLogger = new LuaLogger($filename);
  * Based on parent squad adjusts destination and formation of the squad participants.
  */
 @LuabindClass()
-export class ActionReachTaskLocation extends action_base {
+export class ActionReachTaskLocation extends action_base implements ISchemeEventHandler {
   public nextUpdateAt: TTimestamp = 0;
 
   public reachTargetId!: TNumberId;
@@ -223,7 +224,7 @@ export class ActionReachTaskLocation extends action_base {
   /**
    * todo: Description.
    */
-  public net_destroy(object: ClientObject): void {
+  public onSwitchOffline(object: ClientObject): void {
     this.patrolManager?.removeObjectFromPatrol(object);
   }
 }

--- a/src/engine/core/schemes/remark/actions/ActionRemarkActivity.ts
+++ b/src/engine/core/schemes/remark/actions/ActionRemarkActivity.ts
@@ -3,6 +3,7 @@ import { action_base, level, LuabindClass, patrol } from "xray16";
 import { getObjectIdByStoryId, registry, setStalkerState } from "@/engine/core/database";
 import { SimulationBoardManager } from "@/engine/core/managers/simulation/SimulationBoardManager";
 import { GlobalSoundManager } from "@/engine/core/managers/sounds/GlobalSoundManager";
+import { ISchemeEventHandler } from "@/engine/core/objects/ai/scheme";
 import {
   EStalkerState,
   ILookTargetDescriptor,
@@ -27,7 +28,7 @@ const logger: LuaLogger = new LuaLogger($filename);
  * todo;
  */
 @LuabindClass()
-export class ActionRemarkActivity extends action_base {
+export class ActionRemarkActivity extends action_base implements ISchemeEventHandler {
   public st: ISchemeRemarkState;
   public state: number = stateInitial;
 
@@ -76,7 +77,7 @@ export class ActionRemarkActivity extends action_base {
   /**
    * todo
    */
-  public activateScheme(): void {
+  public activate(): void {
     this.st.signals = new LuaTable();
     this.soundEndSignalled = false;
     this.actionEndSignalled = false;

--- a/src/engine/core/schemes/sleeper/actions/ActionSleeperActivity.ts
+++ b/src/engine/core/schemes/sleeper/actions/ActionSleeperActivity.ts
@@ -51,7 +51,7 @@ export class ActionSleeperActivity extends action_base implements ISchemeEventHa
     this.object.set_desired_position();
     this.object.set_desired_direction();
 
-    this.resetScheme();
+    this.reset();
   }
 
   /**
@@ -62,7 +62,7 @@ export class ActionSleeperActivity extends action_base implements ISchemeEventHa
     super.execute();
 
     if (!this.wasReset) {
-      this.resetScheme();
+      this.reset();
     }
 
     if (this.sleepingState === STATE_WALKING) {
@@ -90,7 +90,14 @@ export class ActionSleeperActivity extends action_base implements ISchemeEventHa
   /**
    * todo: Description.
    */
-  public resetScheme(): void {
+  public activate(): void {
+    this.wasReset = false;
+  }
+
+  /**
+   * todo: Description.
+   */
+  public reset(): void {
     this.timer = {
       begin: null,
       idle: null,
@@ -143,13 +150,6 @@ export class ActionSleeperActivity extends action_base implements ISchemeEventHa
       true
     );
     this.wasReset = true;
-  }
-
-  /**
-   * todo: Description.
-   */
-  public activateScheme(): void {
-    this.wasReset = false;
   }
 
   /**

--- a/src/engine/core/schemes/smartcover/actions/ActionSmartCoverActivity.ts
+++ b/src/engine/core/schemes/smartcover/actions/ActionSmartCoverActivity.ts
@@ -42,7 +42,7 @@ export class ActionSmartCoverActivity extends action_base implements ISchemeEven
 
     this.initialized = true;
 
-    this.activateScheme();
+    this.activate();
   }
 
   /**
@@ -72,7 +72,7 @@ export class ActionSmartCoverActivity extends action_base implements ISchemeEven
   /**
    * todo: Description.
    */
-  public activateScheme(): void {
+  public activate(): void {
     this.state.signals = new LuaTable();
 
     if (!this.initialized) {

--- a/src/engine/core/schemes/sr_crow_spawner/CrowSpawnerManager.ts
+++ b/src/engine/core/schemes/sr_crow_spawner/CrowSpawnerManager.ts
@@ -22,7 +22,7 @@ export class CrowSpawnerManager extends AbstractSchemeManager<ISchemeCrowSpawner
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     for (const [k, v] of this.state.pathsList!) {
       this.spawnPointsIdle.set(v, time_global());
     }

--- a/src/engine/core/schemes/sr_cutscene/CutsceneManager.ts
+++ b/src/engine/core/schemes/sr_cutscene/CutsceneManager.ts
@@ -34,7 +34,7 @@ export class CutsceneManager extends AbstractSchemeManager<ISchemeCutsceneState>
   public motion: Optional<CamEffectorSet> = null;
   public sceneState: ESceneState = ESceneState.NONE;
 
-  public override resetScheme(): void {
+  public override activate(): void {
     logger.info("Reset scheme");
 
     this.sceneState = ESceneState.NONE;

--- a/src/engine/core/schemes/sr_idle/IdleManager.ts
+++ b/src/engine/core/schemes/sr_idle/IdleManager.ts
@@ -7,7 +7,7 @@ import { TCount } from "@/engine/lib/types";
  * todo;
  */
 export class IdleManager extends AbstractSchemeManager<ISchemeIdleState> {
-  public override resetScheme(): void {
+  public override activate(): void {
     this.state.signals = new LuaTable();
   }
 

--- a/src/engine/core/schemes/sr_light/LightManager.ts
+++ b/src/engine/core/schemes/sr_light/LightManager.ts
@@ -16,7 +16,7 @@ export class LightManager extends AbstractSchemeManager<ISchemeLightState> {
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     // logger.info("Reset scheme for:", this.object.name());
     registry.lightZones.set(this.object.id(), this);
   }

--- a/src/engine/core/schemes/sr_monster/MonsterManager.ts
+++ b/src/engine/core/schemes/sr_monster/MonsterManager.ts
@@ -45,7 +45,7 @@ export class MonsterManager extends AbstractSchemeManager<ISchemeMonsterState> {
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     this.isActorInside = false;
 
     this.state.idle_end = 0;

--- a/src/engine/core/schemes/sr_no_weapon/NoWeaponManager.test.ts
+++ b/src/engine/core/schemes/sr_no_weapon/NoWeaponManager.test.ts
@@ -36,7 +36,7 @@ describe("NoWeaponManager class", () => {
     registry.noWeaponZones.set(object.id(), true);
     manager.actorState = EActorZoneState.INSIDE;
 
-    manager.resetScheme();
+    manager.activate();
     manager.actorState = EActorZoneState.NOWHERE;
     expect(registry.noWeaponZones.get(object.id())).toBeNull();
 

--- a/src/engine/core/schemes/sr_no_weapon/NoWeaponManager.ts
+++ b/src/engine/core/schemes/sr_no_weapon/NoWeaponManager.ts
@@ -19,7 +19,7 @@ export class NoWeaponManager extends AbstractSchemeManager<ISchemeNoWeaponState>
    * Instantly assume it is no weapon anymore and reset current states.
    * Recalculate actual state.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     registry.noWeaponZones.delete(this.object.id());
 
     logger.info("Reset no weapon state");

--- a/src/engine/core/schemes/sr_particle/ParticleManager.ts
+++ b/src/engine/core/schemes/sr_particle/ParticleManager.ts
@@ -21,7 +21,7 @@ export class ParticleManager extends AbstractSchemeManager<ISchemeParticleState>
   /**
    * todo: Description.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     if (this.state.mode === 2) {
       this.path = new patrol(this.state.path);
 

--- a/src/engine/core/schemes/sr_postprocess/SchemePostProcessManager.ts
+++ b/src/engine/core/schemes/sr_postprocess/SchemePostProcessManager.ts
@@ -33,7 +33,7 @@ export class SchemePostProcessManager extends AbstractSchemeManager<ISchemePostP
   /**
    * Handle reset event to play anew.
    */
-  public override resetScheme(): void {
+  public override activate(): void {
     this.isActorInside = false;
 
     this.grayAmplitude = 1.0;

--- a/src/engine/core/schemes/sr_psy_antenna/PsyAntennaSchemaManager.ts
+++ b/src/engine/core/schemes/sr_psy_antenna/PsyAntennaSchemaManager.ts
@@ -18,7 +18,7 @@ export class PsyAntennaSchemaManager extends AbstractSchemeManager<ISchemePsyAnt
   /**
    * todo: Description.
    */
-  public override resetScheme(loading?: boolean): void {
+  public override activate(loading?: boolean): void {
     if (loading) {
       this.antennaState = getPortableStoreValue(this.object.id(), "inside")!;
     }

--- a/src/engine/core/schemes/sr_silence/ISchemeSilenceState.ts
+++ b/src/engine/core/schemes/sr_silence/ISchemeSilenceState.ts
@@ -1,4 +1,4 @@
-import type { IBaseSchemeState } from "@/engine/core/objects/ai/scheme/types";
+import type { IBaseSchemeState } from "@/engine/core/objects/ai/scheme/scheme_types";
 
 /**
  * State representing silence management scheme.

--- a/src/engine/core/schemes/sr_timer/TimerManager.test.ts
+++ b/src/engine/core/schemes/sr_timer/TimerManager.test.ts
@@ -20,7 +20,7 @@ describe("TimerManager class", () => {
     const timerManager: TimerManager = new TimerManager(object, state);
     const hud: CUIGameCustom = get_hud();
 
-    timerManager.resetScheme();
+    timerManager.activate();
 
     expect(hud.GetCustomStatic("timer-id")).toBeDefined();
     expect(hud.GetCustomStatic("hud_timer_text")!.wnd().TextControl().GetText()).toBe("timer-label");
@@ -39,7 +39,7 @@ describe("TimerManager class", () => {
     const timerManager: TimerManager = new TimerManager(object, state);
     const hud: CUIGameCustom = get_hud();
 
-    timerManager.resetScheme();
+    timerManager.activate();
 
     expect(hud.GetCustomStatic("timer-id")).toBeDefined();
     expect(hud.GetCustomStatic("hud_timer_text")).toBeNull();

--- a/src/engine/core/schemes/sr_timer/TimerManager.ts
+++ b/src/engine/core/schemes/sr_timer/TimerManager.ts
@@ -15,7 +15,7 @@ const logger: LuaLogger = new LuaLogger($filename);
  * Timer manager to increment/decrement time according to scheme logic and show UI timer.
  */
 export class TimerManager extends AbstractSchemeManager<ISchemeTimerState> {
-  public override resetScheme(): void {
+  public override activate(): void {
     logger.info("Reset timer:", this.object.name());
 
     const hud: CUIGameCustom = get_hud();

--- a/src/engine/core/schemes/walker/actions/ActionWalkerActivity.ts
+++ b/src/engine/core/schemes/walker/actions/ActionWalkerActivity.ts
@@ -15,6 +15,9 @@ import { ClientObject, Optional } from "@/engine/lib/types";
 
 const logger: LuaLogger = new LuaLogger($filename);
 
+// todo: Remove?
+// todo: Remove?
+// todo: Remove?
 const ASSOC_TBL = {
   idle: { director: ["wait"] },
   harmonica: { director: ["play_harmonica"] },
@@ -63,7 +66,7 @@ export class ActionWalkerActivity extends action_base implements ISchemeEventHan
     this.object.set_desired_position();
     this.object.set_desired_direction();
 
-    this.resetScheme(false, this.object);
+    this.reset(false, this.object);
   }
 
   /**
@@ -80,6 +83,40 @@ export class ActionWalkerActivity extends action_base implements ISchemeEventHan
     }
 
     super.finalize();
+  }
+
+  /**
+   * todo: Description.
+   */
+  public activate(isLoading: boolean, object: ClientObject): void {
+    this.state.signals = new LuaTable();
+    this.reset(isLoading, object);
+  }
+
+  /**
+   * todo: Description.
+   */
+  public reset(isLoading: boolean, object: ClientObject): void {
+    if (this.state.path_walk_info === null) {
+      this.state.path_walk_info = parseWaypointsData(this.state.path_walk);
+    }
+
+    if (this.state.path_look_info === null) {
+      this.state.path_look_info = parseWaypointsData(this.state.path_look);
+    }
+
+    this.moveManager.reset(
+      this.state.path_walk,
+      this.state.path_walk_info,
+      this.state.path_look,
+      this.state.path_look_info,
+      this.state.team,
+      this.state.suggested_state,
+      null,
+      null,
+      null,
+      null
+    );
   }
 
   /**
@@ -131,51 +168,10 @@ export class ActionWalkerActivity extends action_base implements ISchemeEventHan
   /**
    * todo: Description.
    */
-  public isPositionReached(): boolean {
-    return this.moveManager.isArrivedToFirstWaypoint();
-  }
-
-  /**
-   * todo: Description.
-   */
-  public net_destroy(object: ClientObject): void {
+  public onSwitchOffline(object: ClientObject): void {
     if (this.isInCamp === true) {
       this.campStoryManager!.unregisterObject(object.id());
       this.isInCamp = null;
     }
-  }
-
-  /**
-   * todo: Description.
-   */
-  public activateScheme(isLoading: boolean, object: ClientObject): void {
-    this.state.signals = new LuaTable();
-    this.resetScheme(isLoading, object);
-  }
-
-  /**
-   * todo: Description.
-   */
-  public resetScheme(isLoading: boolean, object: ClientObject): void {
-    if (this.state.path_walk_info === null) {
-      this.state.path_walk_info = parseWaypointsData(this.state.path_walk);
-    }
-
-    if (this.state.path_look_info === null) {
-      this.state.path_look_info = parseWaypointsData(this.state.path_look);
-    }
-
-    this.moveManager.reset(
-      this.state.path_walk,
-      this.state.path_walk_info,
-      this.state.path_look,
-      this.state.path_look_info,
-      this.state.team,
-      this.state.suggested_state,
-      null,
-      null,
-      null,
-      null
-    );
   }
 }

--- a/src/engine/core/utils/scheme/scheme_event.test.ts
+++ b/src/engine/core/utils/scheme/scheme_event.test.ts
@@ -17,29 +17,29 @@ describe("'scheme logic' utils", () => {
     const object: ClientObject = mockClientGameObject();
     const schemeState: IBaseSchemeState = mockSchemeState(object, EScheme.MEET);
     const mockAction = {
-      activateScheme: jest.fn(),
+      activate: jest.fn(),
       deactivate: jest.fn(),
+      save: jest.fn(),
+      update: jest.fn(),
       onDeath: jest.fn(),
       onCutscene: jest.fn(),
       onExtrapolate: jest.fn(),
-      net_destroy: jest.fn(),
+      onSwitchOnline: jest.fn(),
+      onSwitchOffline: jest.fn(),
       onHit: jest.fn(),
-      resetScheme: jest.fn(),
-      save: jest.fn(),
-      update: jest.fn(),
       onUse: jest.fn(),
       onWaypoint: jest.fn(),
     };
 
-    expect(() => emitSchemeEvent(object, schemeState, ESchemeEvent.ACTIVATE_SCHEME)).not.toThrow();
+    expect(() => emitSchemeEvent(object, schemeState, ESchemeEvent.ACTIVATE)).not.toThrow();
 
     schemeState.actions = new LuaTable();
-    expect(() => emitSchemeEvent(object, schemeState, ESchemeEvent.ACTIVATE_SCHEME)).not.toThrow();
+    expect(() => emitSchemeEvent(object, schemeState, ESchemeEvent.ACTIVATE)).not.toThrow();
 
     schemeState.actions.set(mockAction, true);
 
-    emitSchemeEvent(object, schemeState, ESchemeEvent.ACTIVATE_SCHEME, object, 1, 2, 3);
-    expect(mockAction.activateScheme).toHaveBeenCalledWith(object, 1, 2, 3);
+    emitSchemeEvent(object, schemeState, ESchemeEvent.ACTIVATE, object, 1, 2, 3);
+    expect(mockAction.activate).toHaveBeenCalledWith(object, 1, 2, 3);
 
     emitSchemeEvent(object, schemeState, ESchemeEvent.DEACTIVATE);
     expect(mockAction.deactivate).toHaveBeenCalledTimes(1);
@@ -53,14 +53,14 @@ describe("'scheme logic' utils", () => {
     emitSchemeEvent(object, schemeState, ESchemeEvent.EXTRAPOLATE);
     expect(mockAction.onExtrapolate).toHaveBeenCalledTimes(1);
 
-    emitSchemeEvent(object, schemeState, ESchemeEvent.NET_DESTROY);
-    expect(mockAction.net_destroy).toHaveBeenCalledTimes(1);
+    emitSchemeEvent(object, schemeState, ESchemeEvent.SWITCH_OFFLINE);
+    expect(mockAction.onSwitchOffline).toHaveBeenCalledTimes(1);
+
+    emitSchemeEvent(object, schemeState, ESchemeEvent.SWITCH_ONLINE);
+    expect(mockAction.onSwitchOnline).toHaveBeenCalledTimes(1);
 
     emitSchemeEvent(object, schemeState, ESchemeEvent.HIT);
     expect(mockAction.onHit).toHaveBeenCalledTimes(1);
-
-    emitSchemeEvent(object, schemeState, ESchemeEvent.RESET_SCHEME);
-    expect(mockAction.resetScheme).toHaveBeenCalledTimes(1);
 
     emitSchemeEvent(object, schemeState, ESchemeEvent.SAVE);
     expect(mockAction.save).toHaveBeenCalledTimes(1);

--- a/src/engine/core/utils/scheme/scheme_logic.test.ts
+++ b/src/engine/core/utils/scheme/scheme_logic.test.ts
@@ -219,7 +219,7 @@ describe("'scheme logic' utils", () => {
     state.schemeType = ESchemeType.RESTRICTOR;
 
     jest.spyOn(SchemeIdle, "activate");
-    jest.spyOn(IdleManager.prototype, "resetScheme");
+    jest.spyOn(IdleManager.prototype, "activate");
 
     expect(() => activateSchemeBySection(object, ini, "sr_idle@test", null, false)).toThrow();
 
@@ -232,7 +232,7 @@ describe("'scheme logic' utils", () => {
     expect(state.activeSection).toBe("sr_idle@test");
     expect(state.activeScheme).toBe(EScheme.SR_IDLE);
     expect(SchemeIdle.activate).toHaveBeenCalledWith(object, ini, EScheme.SR_IDLE, "sr_idle@test", null);
-    expect(getSchemeAction(state[EScheme.SR_IDLE] as IBaseSchemeState).resetScheme).toHaveBeenCalledWith(false, object);
+    expect(getSchemeAction(state[EScheme.SR_IDLE] as IBaseSchemeState).activate).toHaveBeenCalledWith(false, object);
   });
 
   it("'activateSchemeBySection' should correctly change generic sections", () => {
@@ -248,7 +248,7 @@ describe("'scheme logic' utils", () => {
     state.schemeType = ESchemeType.STALKER;
 
     jest.spyOn(SchemeHit, "activate");
-    jest.spyOn(HitManager.prototype, "activateScheme");
+    jest.spyOn(HitManager.prototype, "activate");
     jest.spyOn(MapDisplayManager.getInstance(), "updateObjectMapSpot").mockImplementation(jest.fn());
 
     loadGenericSchemes();
@@ -259,7 +259,7 @@ describe("'scheme logic' utils", () => {
     expect(state.activeScheme).toBe(EScheme.HIT);
     expect(SchemeHit.activate).toHaveBeenCalledWith(object, ini, EScheme.HIT, "hit@test", null);
     expect(object.set_dest_level_vertex_id).toHaveBeenCalledWith(255);
-    expect(getSchemeAction(state[EScheme.HIT] as IBaseSchemeState).activateScheme).toHaveBeenCalledWith(false, object);
+    expect(getSchemeAction(state[EScheme.HIT] as IBaseSchemeState).activate).toHaveBeenCalledWith(false, object);
 
     expect(state.overrides).toEqualLuaTables({
       combat_ignore: null,

--- a/src/engine/core/utils/scheme/scheme_logic.ts
+++ b/src/engine/core/utils/scheme/scheme_logic.ts
@@ -160,13 +160,11 @@ export function activateSchemeBySection(
   state.activeSection = section;
   state.activeScheme = scheme;
 
-  // todo: Unify activate and reset events.
   if (state.schemeType === ESchemeType.STALKER) {
     sendToNearestAccessibleVertex(object, object.level_vertex_id());
-    emitSchemeEvent(object, state[scheme] as IBaseSchemeState, ESchemeEvent.ACTIVATE_SCHEME, isLoading, object);
-  } else {
-    emitSchemeEvent(object, state[scheme] as IBaseSchemeState, ESchemeEvent.RESET_SCHEME, isLoading, object);
   }
+
+  emitSchemeEvent(object, state[scheme] as IBaseSchemeState, ESchemeEvent.ACTIVATE, isLoading, object);
 }
 
 /**

--- a/src/engine/core/utils/scheme/scheme_switch.test.ts
+++ b/src/engine/core/utils/scheme/scheme_switch.test.ts
@@ -662,13 +662,13 @@ describe("'switch logic' utils", () => {
     expect(switchObjectSchemeToSection(object, ini, null)).toBe(false);
     expect(handler.deactivate).not.toHaveBeenCalled();
 
-    jest.spyOn(TimerManager.prototype, "resetScheme").mockImplementation(jest.fn);
+    jest.spyOn(TimerManager.prototype, "activate").mockImplementation(jest.fn);
 
     expect(switchObjectSchemeToSection(object, ini, "sr_timer@next")).toBe(true);
     expect(handler.deactivate).toHaveBeenCalledTimes(1);
     expect(state.activeScheme).toBe(EScheme.SR_TIMER);
     expect(state.activeSection).toBe("sr_timer@next");
     expect(state[EScheme.SR_TIMER]).toBeDefined();
-    expect(getSchemeAction(state[EScheme.SR_TIMER] as IBaseSchemeState).resetScheme).toHaveBeenCalledTimes(1);
+    expect(getSchemeAction(state[EScheme.SR_TIMER] as IBaseSchemeState).activate).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Previously scheme activation event was 'activateScheme' for stalkers and 'resetScheme' for other objects.

## Changes
- Unify scheme reset and scheme activate
- Rename handle for go offline event
- Generic improvements to make naming less verbose and more obvious
- scheme/types.ts -> scheme/scheme_types.ts
- require scheme subscribers to implement scheme events interface
- stop scheme events subscription for some actions where it is not used